### PR TITLE
Terraform example!

### DIFF
--- a/examples/terraform/.gitignore
+++ b/examples/terraform/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+.terraform.lock.hcl
+terraform.tfstate*

--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -1,0 +1,12 @@
+# Examples
+
+This folder contains examples of the Foundation SDK being used in combination with [Terraform](https://www.terraform.io/) and the [Grafana Provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs). 
+
+While the Foundation SDK does not integrate directly with TF/the HCL language, it can be used in Terraform "external datasources". Building dashboards is a complex problem that is hard to model/reason with in the HCL language.
+
+## Running this example
+
+```console
+$ terraform init
+$ terraform apply
+```

--- a/examples/terraform/dashboards.tf
+++ b/examples/terraform/dashboards.tf
@@ -1,0 +1,27 @@
+locals {
+  go_builders = toset([
+    "${path.module}/../go/custom-panel",
+    "${path.module}/../go/custom-query",
+    "${path.module}/../go/grafana-agent-overview",
+    "${path.module}/../go/linux-node-overview",
+    "${path.module}/../go/red-method",
+  ])
+}
+
+// List and run the go dashboard builders. Any of the languages would also work.
+// We are using jq to convert the output to a map of strings, as expected by the external data source.
+// The dashboard building could be done with a single Go program that outputs the expected TF format,
+// but this example does it in multiple Go calls in order to reuse the existing examples.
+data "external" "dashboards" {
+  for_each    = local.go_builders
+  working_dir = each.value
+  program = ["bash", "-c", <<EOF
+  go run *.go | jq '{"dashboard": . | tostring}'
+EOF
+  ]
+}
+
+resource "grafana_dashboard" "examples" {
+  for_each    = local.go_builders
+  config_json = data.external.dashboards[each.key].result.dashboard
+}

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "3.1.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "admin:admin"
+}


### PR DESCRIPTION
This adds a showcase of how to use the Foundation SDK from Terraform directly 
Terraform has the external datasource (https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) that can call any external tool to introduce data 

We can use this datasource to call the Foundation SDK in whatever language the user wants to use