### PR TITLE
fix randomWalk in examples

### DIFF
--- a/examples/go/red-method/red.go
+++ b/examples/go/red-method/red.go
@@ -49,11 +49,11 @@ func requestRateTimeseries() *timeseries.PanelBuilder {
 	return defaultTimeseries().
 		Title("Request rate").
 		Description("Number of requests handled by the service, per second.").
-		Datasource(grafanaDatasourceRef()).
 		Unit("reqps").
 		WithTarget(
 			testdata.NewDataqueryBuilder().
-				QueryType("randomWalk"),
+				QueryType("randomWalk").
+				Datasource(grafanaDatasourceRef()),
 		)
 }
 
@@ -61,11 +61,11 @@ func errorRateTimeseries() *timeseries.PanelBuilder {
 	return defaultTimeseries().
 		Title("Error rate").
 		Description("Number of failed requests, per second.").
-		Datasource(grafanaDatasourceRef()).
 		Unit("reqps").
 		WithTarget(
 			testdata.NewDataqueryBuilder().
-				QueryType("randomWalk"),
+				QueryType("randomWalk").
+				Datasource(grafanaDatasourceRef()),
 		)
 }
 
@@ -77,6 +77,7 @@ func durationTimeseries() *timeseries.PanelBuilder {
 		Unit("s").
 		WithTarget(
 			testdata.NewDataqueryBuilder().
-				QueryType("randomWalk"),
+				QueryType("randomWalk").
+				Datasource(grafanaDatasourceRef()),
 		)
 }

--- a/examples/python/red-method/main.py
+++ b/examples/python/red-method/main.py
@@ -3,10 +3,10 @@ from grafana_foundation_sdk.cog.encoder import JSONEncoder
 from src.red import red
 
 
-if __name__ == '__main__':
-    red_dashboard = red(
-        dashboard_title="RED method",
-        service_ids=["sample-service", "payments", "front-gateway"],
-    )
+red_dashboard = red(
+    dashboard_title="RED method",
+    service_ids=["sample-service", "payments", "front-gateway"],
+)
 
+if __name__ == '__main__':
     print(JSONEncoder(sort_keys=True, indent=2).encode(red_dashboard.build()))

--- a/examples/python/red-method/src/red.py
+++ b/examples/python/red-method/src/red.py
@@ -44,10 +44,10 @@ def request_rate_timeseries() -> timeseries.Panel:
         default_timeseries()
         .title("Request rate")
         .description("Number of requests handled by the service, per second.")
-        .datasource(DataSourceRef(uid="grafana", type_val="grafana"))
         .unit("reqps")
         .with_target(
             testdata.Dataquery().query_type("randomWalk")
+            .datasource(DataSourceRef(uid="grafana", type_val="grafana"))
         )
     )
 
@@ -57,10 +57,10 @@ def error_rate_timeseries() -> timeseries.Panel:
         default_timeseries()
         .title("Error rate")
         .description("Number of failed requests, per second.")
-        .datasource(DataSourceRef(uid="grafana", type_val="grafana"))
         .unit("reqps")
         .with_target(
             testdata.Dataquery().query_type("randomWalk")
+            .datasource(DataSourceRef(uid="grafana", type_val="grafana"))
         )
     )
 
@@ -70,9 +70,9 @@ def duration_timeseries() -> timeseries.Panel:
         default_timeseries()
         .title("Duration")
         .description("Time taken to process the requests.")
-        .datasource(DataSourceRef(uid="grafana", type_val="grafana"))
         .unit("s")
         .with_target(
             testdata.Dataquery().query_type("randomWalk")
+            .datasource(DataSourceRef(uid="grafana", type_val="grafana"))
         )
     )


### PR DESCRIPTION
The randomWalk targets in some of the examples are formatted incorrectly. This PR fixes **some** of them.

I have not been thorough in checking for every erroneous kind. I'm making this PR just to capture the error.

I've also made an adjustment to the Python `red-method` example that allows it to be used as a module rather than executed directly. This brings it in line with other examples.
