### PR TITLE
Fix duplicated publishConfig in package.json

### DIFF
--- a/.cog/package_templates/typescript/package.json
+++ b/.cog/package_templates/typescript/package.json
@@ -55,9 +55,6 @@
     "babel-loader": "^8.2.2",
     "typescript": "^5.0.0"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "tslib": "^2.6.2"
   }


### PR DESCRIPTION
This section of the package.json is already defined in the beginning of the file.