### PR TITLE
Add a schema for the bigquery datasource plugin

### DIFF
--- a/.cog/compiler/bigquery.yaml
+++ b/.cog/compiler/bigquery.yaml
@@ -1,5 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/compiler_passes.json
-
-passes:
-  - dataquery_identification: {}
-  - schema_set_identifier: { package: bigquery, identifier: "grafana-bigquery-datasource" }

--- a/.cog/compiler/bigquery.yaml
+++ b/.cog/compiler/bigquery.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/compiler_passes.json
+
+passes:
+  - dataquery_identification: {}
+  - schema_set_identifier: { package: bigquery, identifier: "grafana-bigquery-datasource" }

--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -80,6 +80,16 @@ inputs:
       cue_imports:
         - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
 
+  # The schema for athena queries
+  - cue:
+      entrypoint: '%__config_dir%/../schemas/composable/athena'
+      metadata:
+        kind: composable
+        variant: dataquery
+        identifier: grafana-athena-datasource
+      cue_imports:
+        - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
+
 transformations:
   schemas:
     - '%__config_dir%/compiler/common_passes.yaml'

--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -70,6 +70,17 @@ inputs:
       transformations:
         - '%__config_dir%/compiler/prometheus.yaml'
 
+  # The schema for bigquery queries
+  - cue:
+      entrypoint: '%__config_dir%/schemas/composable/bigquery'
+      metadata:
+        kind: composable
+        variant: dataquery
+      cue_imports:
+        - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
+      transformations:
+        - '%__config_dir%/compiler/bigquery.yaml'
+
 transformations:
   schemas:
     - '%__config_dir%/compiler/common_passes.yaml'

--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -76,10 +76,9 @@ inputs:
       metadata:
         kind: composable
         variant: dataquery
+        identifier: grafana-bigquery-datasource
       cue_imports:
         - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
-      transformations:
-        - '%__config_dir%/compiler/bigquery.yaml'
 
 transformations:
   schemas:

--- a/.cog/schemas/composable/athena/dataquery.cue
+++ b/.cog/schemas/composable/athena/dataquery.cue
@@ -1,0 +1,31 @@
+package athena
+
+import (
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
+)
+
+// Manually converted from https://github.com/grafana/athena-datasource/blob/57ad707147b7a11e9a521a836d6bf9799877e0e3/src/types.ts
+Dataquery: {
+  common.DataQuery
+
+	format: #FormatOptions
+	connectionArgs: #ConnectionArgs
+	table?: string
+	column?: string
+
+	queryID?: string
+
+	rawSQL: string | *""
+}
+
+defaultKey: "__default"
+
+#ConnectionArgs: {
+	region?: string | *defaultKey
+	catalog?: string | *defaultKey
+	database?: string | *defaultKey
+	resultReuseEnabled?: bool | *false
+	resultReuseMaxAgeInMinutes?: number | *60
+}
+
+#FormatOptions: 0 | 1 | 2 @cog(kind="enum", memberNames="TimeSeries|Table|Logs")

--- a/.cog/schemas/composable/bigquery/dataquery.cue
+++ b/.cog/schemas/composable/bigquery/dataquery.cue
@@ -1,0 +1,76 @@
+package bigquery
+
+import (
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
+)
+
+// Manually converted from https://github.com/grafana/google-bigquery-datasource/blob/18680e42ba557791d109c7c540c2c3f2647592f0/src/types.ts#L75
+Dataquery: {
+    common.DataQuery
+
+    dataset?: string
+    table?: string
+    project?: string
+
+    format: #QueryFormat
+    rawQuery?: bool
+    rawSql: string
+    location?: string
+
+    partitioned?: bool
+    partitionedField?: string
+    convertToUTC?: bool
+    sharded?: bool
+    queryPriority?: #QueryPriority
+    timeShift?: string
+    editorMode?: #EditorMode
+    sql?: #SQLExpression
+
+    #QueryFormat: 0 | 1 @cog(kind="enum", memberNames="Timeseries|Table")
+    #QueryPriority: "INTERACTIVE" | "BATCH" @cog(kind="enum", memberNames="Interactive|Batch")
+    #EditorMode: "code" | "builder"
+
+    #SQLExpression: {
+        columns?: [...#QueryEditorFunctionExpression]
+        from?: string
+        // whereJsonTree?: _
+        whereString?: string
+        groupBy?: [...#QueryEditorGroupByExpression]
+        orderBy?: #QueryEditorPropertyExpression
+        orderByDirection?: #OrderByDirection
+        limit?: int
+        offset?: int
+    }
+
+    #QueryEditorExpressionType: "property" | "operator" | "or" | "and" | "groupBy" | "function" | "functionParameter"
+
+    #QueryEditorFunctionExpression: {
+        type: #QueryEditorExpressionType & "function"
+        name?: string
+        parameters?: [...#QueryEditorFunctionParameterExpression]
+    }
+
+    #QueryEditorFunctionParameterExpression: {
+        type: #QueryEditorExpressionType & "functionParameter"
+        name?: string
+    }
+
+    #QueryEditorGroupByExpression: {
+        type: #QueryEditorExpressionType & "groupBy"
+        property: #QueryEditorProperty
+    }
+
+    #QueryEditorProperty: {
+        type: #QueryEditorPropertyType
+        name?: string
+    }
+
+    #QueryEditorPropertyType: "string" @cog(kind="enum")
+
+    #QueryEditorPropertyExpression: {
+        type: #QueryEditorExpressionType & "property"
+        property: #QueryEditorProperty
+    }
+
+    #OrderByDirection: "ASC" | "DESC"
+}


### PR DESCRIPTION
This PR defines the necessary schema to support queries for the [`google-bigquery-datasource`](https://github.com/grafana/google-bigquery-datasource) plugin