### PR TITLE
Add a schema for the athena datasource plugin

### DIFF
--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -80,6 +80,16 @@ inputs:
       cue_imports:
         - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
 
+  # The schema for athena queries
+  - cue:
+      entrypoint: '%__config_dir%/../schemas/composable/athena'
+      metadata:
+        kind: composable
+        variant: dataquery
+        identifier: grafana-athena-datasource
+      cue_imports:
+        - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
+
 transformations:
   schemas:
     - '%__config_dir%/compiler/common_passes.yaml'

--- a/.cog/schemas/composable/athena/dataquery.cue
+++ b/.cog/schemas/composable/athena/dataquery.cue
@@ -1,0 +1,31 @@
+package athena
+
+import (
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
+)
+
+// Manually converted from https://github.com/grafana/athena-datasource/blob/57ad707147b7a11e9a521a836d6bf9799877e0e3/src/types.ts
+Dataquery: {
+  common.DataQuery
+
+	format: #FormatOptions
+	connectionArgs: #ConnectionArgs
+	table?: string
+	column?: string
+
+	queryID?: string
+
+	rawSQL: string | *""
+}
+
+defaultKey: "__default"
+
+#ConnectionArgs: {
+	region?: string | *defaultKey
+	catalog?: string | *defaultKey
+	database?: string | *defaultKey
+	resultReuseEnabled?: bool | *false
+	resultReuseMaxAgeInMinutes?: number | *60
+}
+
+#FormatOptions: 0 | 1 | 2 @cog(kind="enum", memberNames="TimeSeries|Table|Logs")


### PR DESCRIPTION
This PR defines the necessary schema to support queries for the [athena-datasource](https://github.com/grafana/athena-datasource) plugin