### PR TITLE
Group logs by version in release-all.sh script

### DIFF
--- a/scripts/docs/build.sh
+++ b/scripts/docs/build.sh
@@ -29,6 +29,8 @@ echo '[]' > "${docs_build_dir}/versions.json"
 
 for short_version in ${ALL_GRAFANA_VERSIONS//;/ } ; do
     full_version="${short_version}+cog-${COG_VERSION}"
+
+    log_group_start "Building documentation for version ${full_version}"
     echo "🪧 Building documentation for version ${full_version}"
 
     cat <<< $(jq ". += [{\"version\": \"${full_version}\", \"title\": \"${short_version}\"}]" "${docs_build_dir}/versions.json") > "${docs_build_dir}/versions.json"
@@ -38,4 +40,6 @@ for short_version in ${ALL_GRAFANA_VERSIONS//;/ } ; do
     echo "🪧 Minifying HTML"
     minhtml --do-not-minify-doctype --ensure-spec-compliant-unquoted-attribute-values --keep-closing-tags --keep-input-type-text-attr --keep-html-and-head-opening-tags --preserve-brace-template-syntax --keep-spaces-between-attributes ${docs_build_dir}/${full_version}/*/*/*/*.html
     minhtml --do-not-minify-doctype --ensure-spec-compliant-unquoted-attribute-values --keep-closing-tags --keep-input-type-text-attr --keep-html-and-head-opening-tags --preserve-brace-template-syntax --keep-spaces-between-attributes ${docs_build_dir}/${full_version}/*/*/*/*/*.html
+
+    log_group_end
 done

--- a/scripts/libs/logs.sh
+++ b/scripts/libs/logs.sh
@@ -57,3 +57,13 @@ function warning()   { [[ "${LOG_LEVEL:-0}" -ge 4 ]] && __log warning "${@}"; tr
 function notice()    { [[ "${LOG_LEVEL:-0}" -ge 5 ]] && __log notice "${@}"; true; }
 function info()      { [[ "${LOG_LEVEL:-0}" -ge 6 ]] && __log info "${@}"; true; }
 function debug()     { [[ "${LOG_LEVEL:-0}" -ge 7 ]] && __log debug "${@}"; true; }
+
+function log_group_start() {
+  [[ "${GITHUB_ACTIONS:-}" == "true" ]] && echo "::group::${1}"
+  true
+}
+
+function log_group_end() {
+  [[ "${GITHUB_ACTIONS:-}" == "true" ]] && echo "::endgroup::"
+  true
+}

--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -20,13 +20,17 @@ source "${__dir}/versions.sh"
 ### Usage ###
 #################
 
-# LOG_LEVEL=7 ./scripts/release-version.sh v10.2.x
+# LOG_LEVEL=7 ./scripts/release-all.sh
 
 ############
 ### Main ###
 ############
 
 for version in ${ALL_GRAFANA_VERSIONS//;/ } ; do
+  log_group_start "Releasing ${version}"
+
   info "🪧 Releasing ${bold}${version}${normal}"
   $__dir/release-version.sh "${version}"
+
+  log_group_end
 done


### PR DESCRIPTION
Grouping the logs by version should make them a tiny bit less painful to read