### PR TITLE
Update dashboard veneers to use the fully generic `compose` veneer

### DIFF
--- a/.cog/veneers/dashboard.common.yaml
+++ b/.cog/veneers/dashboard.common.yaml
@@ -67,13 +67,14 @@ builders:
       under_path: fieldConfig
 
   # Panels composability
-  - compose_dashboard_panel:
-      panel_builder_name: dashboard.Panel
+  - compose:
+      by_variant: panelcfg
+      source_builder_name: dashboard.Panel
       plugin_discriminator_field: type
       composition_map:
         Options: options
         FieldConfig: fieldConfig.defaults.custom
-      exclude_panel_options: [
+      exclude_options: [
         # merged with another builder
         "defaults",
         "fieldConfig",

--- a/.github/actions/setup-cog/action.yaml
+++ b/.github/actions/setup-cog/action.yaml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "Cog version to install"
     required: true
-    default: "0.0.7"
+    default: "0.0.8"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This veneer changed in grafana/cog#680