### PR TITLE
Add a veneer to help with panels within rows

### DIFF
--- a/.cog/veneers/dashboard.common.yaml
+++ b/.cog/veneers/dashboard.common.yaml
@@ -183,6 +183,23 @@ options:
       by_name: RowPanel.panels
       as: withPanel
 
+  # Panels added directly to a row will be stripped by Grafana unless the row is collapsed.
+  - add_assignment:
+      by_name: RowPanel.withPanel
+      assignment:
+        path: collapsed
+        method: direct
+        value: { constant: true }
+  - add_comments:
+      by_name: RowPanel.withPanel
+      comments:
+        - 'Note: since panels added directly to a row will be stripped by Grafana unless the row is collapsed,'
+        - 'this option will set the current row as collapsed.'
+  - add_comments:
+      by_name: RowPanel.collapsed
+      comments:
+        - 'Note: panels added directly to a row will be stripped by Grafana unless the row is collapsed'
+
   # Templating([]VariableModel) instead of Templating(struct []struct{List []VariableModel})
   - struct_fields_as_arguments:
       by_name: Dashboard.templating

--- a/.github/actions/setup-cog/action.yaml
+++ b/.github/actions/setup-cog/action.yaml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "Cog version to install"
     required: true
-    default: "0.0.10"
+    default: "0.0.11"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Relates to #504

Adding panels directly into a row doesn't work as expected if the row isn't collapsed (that's Grafana's behavior, it's not related to the SDK).

To help a bit with this surprising behavior, this PR adds a comment to the `row.withPanel()` option to explain this behavior and toggles the `collapse` field.