### PR TITLE
Fix unmarshalling of `common.TableFooterOptions.fields` in Go

### DIFF
--- a/.cog/templates/go/overrides/object_common_TableFooterOptions_custom_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_common_TableFooterOptions_custom_unmarshal.tmpl
@@ -1,0 +1,49 @@
+{{- define "object_common_TableFooterOptions_custom_unmarshal" }}
+{{- /* Non-standard unmarshalling needed because even though the "fields" field
+	   is typed as []string in the schema, Grafana uses `""` as an empty value 
+*/ -}}
+{{- $fmt := importStdPkg "fmt" -}}
+{{- $json := importStdPkg "encoding/json" -}}
+func (resource *{{ .Object.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error {
+    if raw == nil {
+        return nil
+    }
+
+    fields := make(map[string]json.RawMessage)
+    if err := json.Unmarshal(raw, &fields); err != nil {
+        return err
+    }
+    {{- range $field := .Object.Type.Struct.Fields }}
+    {{- if eq $field.Name "fields" }}
+    {{ template "unmarshal_common_TableFooterOptions_fields" }}
+    {{- else }}
+    if fields["{{ $field.Name }}"] != nil {
+		if err := json.Unmarshal(fields["{{ $field.Name }}"], &resource.{{ $field.Name|upperCamelCase }}); err != nil {
+			return fmt.Errorf("error decoding field '{{ $field.Name }}': %w", err)
+		}
+	}
+    {{- end }}
+    {{- end }}
+
+    return nil
+}
+
+{{ end }}
+
+{{- define "unmarshal_common_TableFooterOptions_fields" -}}
+	rawFields := fields["fields"]
+
+	if rawFields != nil {		
+		if len(rawFields) != 0 && rawFields[0] == '"' {
+			var field string
+			if err := json.Unmarshal(rawFields, &field); err != nil {
+				return fmt.Errorf("error decoding field 'fields': %w", err)
+			}
+			resource.Fields = []string{field}
+		} else {
+			if err := json.Unmarshal(rawFields, &resource.Fields); err != nil {
+				return fmt.Errorf("error decoding field 'fields': %w", err)
+			}
+		}
+	}
+{{- end -}}

--- a/.cog/templates/go/overrides/object_common_TableFooterOptions_field_fields_custom_strict_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_common_TableFooterOptions_field_fields_custom_strict_unmarshal.tmpl
@@ -1,0 +1,18 @@
+{{- define "object_common_TableFooterOptions_field_fields_custom_strict_unmarshal" -}}
+{{- /* Non-standard unmarshalling needed because even though the "fields" field
+	   is typed as []string in the schema, Grafana uses `""` as an empty value 
+*/ -}}
+	if len(fields["fields"]) != 0 && fields["fields"][0] == '"' {
+		var field string
+		if err := json.Unmarshal(fields["fields"], &field); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("fields", err)...)
+		} else {
+			resource.Fields = []string{field}
+		}
+	} else {
+		if err := json.Unmarshal(fields["fields"], &resource.Fields); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("fields", err)...)
+		}
+	}
+
+{{ end }}


### PR DESCRIPTION
Fixes #562 

This field is described as a `[...string]` in the schema, but Grafana can store a string in it.