### PR TITLE
Add "datasource" dataquery to help with reusing queries across panels

### DIFF
--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -112,6 +112,16 @@ inputs:
       cue_imports:
         - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
 
+  # The schema for "datasource" queries
+  - cue:
+      entrypoint: '%__config_dir%/schemas/composable/datasource'
+      metadata:
+        kind: composable
+        variant: dataquery
+        identifier: datasource
+      cue_imports:
+        - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
+
 transformations:
   schemas:
     - '%__config_dir%/compiler/common_passes.yaml'

--- a/.cog/schemas/composable/datasource/dataquery.cue
+++ b/.cog/schemas/composable/datasource/dataquery.cue
@@ -1,0 +1,12 @@
+package datasource
+
+import (
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
+)
+
+Dataquery: {
+	common.DataQuery
+
+	// Panel ID from wich the queries will be reused.
+	panelId: uint32
+}

--- a/.cog/veneers/datasource.common.yaml
+++ b/.cog/veneers/datasource.common.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+language: all
+
+package: datasource
+
+options:
+  - omit: { by_name: Dataquery.queryType }


### PR DESCRIPTION
Fixes #510

To reuse a query defined by another panel, this new "datasource" dataquery can be used:

```go
timeseries.NewPanelBuilder().
  Title("CPU usage").
  Datasource(dashboard.DataSourceRef{
    Uid:  cog.ToPtr("-- Mixed --"),
    Type: cog.ToPtr("datasource"),
  }).
  WithTarget(
    datasource.NewDataqueryBuilder().
      // ID of the panel defining the query/queries to re-use (can be set from the SDK by calling the `ID()` method on the panel builder)
      PanelId(42).
      Datasource(dashboard.DataSourceRef{
        Uid:  cog.ToPtr("-- Dashboard --"),
        Type: cog.ToPtr("datasource"),
      }),
  )
```