### PR TITLE
Trigger Java/Python/Typescript releases on push

### DIFF
--- a/.cog/repository_templates/java/.github/workflows/java-release.yaml
+++ b/.cog/repository_templates/java/.github/workflows/java-release.yaml
@@ -1,18 +1,14 @@
 name: Java Release
 on:
-  pull_request_target:
-    types: [ closed ]
-    paths:
-      - 'java/gradle.properties'
-      - 'java/src/**'
+  push:
+    branches:
+      - '{{ .Extra.ReleaseBranch }}'
 
 env:
   JAVA_VERSION: '17'
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && github.base_ref == '{{ .Extra.ReleaseBranch }}'
-
     name: Build and release
     runs-on: ubuntu-latest
 

--- a/.cog/repository_templates/python/.github/workflows/python-release.yaml
+++ b/.cog/repository_templates/python/.github/workflows/python-release.yaml
@@ -1,18 +1,14 @@
 name: Python Release
 on:
-  pull_request_target:
-    types: [ closed ]
-    paths:
-      - 'python/pyproject.toml'
-      - 'python/grafana_foundation_sdk/**'
+  push:
+    branches:
+      - '{{ .Extra.ReleaseBranch }}'
 
 env:
   PYTHON_VERSION: '3.12'
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && github.base_ref == '{{ .Extra.ReleaseBranch }}'
-
     name: Build and release
     runs-on: ubuntu-latest
 

--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.yaml
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.yaml
@@ -1,18 +1,14 @@
 name: TypeScript Release
 on:
-  pull_request_target:
-    types: [closed]
-    paths:
-      - 'typescript/package.json'
-      - 'typescript/src/**'
+  push:
+    branches:
+      - '{{ .Extra.ReleaseBranch }}'
 
 env:
   NODE_VERSION: '18'
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && github.base_ref == '{{ .Extra.ReleaseBranch }}'
-
     name: Build and release
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
For some reason, merging release PRs (such as [this one](https://github.com/grafana/grafana-foundation-sdk/pull/611)) doesn't always trigger a release.

With this PR, I try to work around this problem by starting the release process for languages who need packaging + publishing (Java/Python/Typescript) on push to the "main version branch".

We do lose the checks on modified paths... but it's not a big deal since any push to these version branches is always done in the context of a release and should trigger the actions.