### PR TITLE
Delete default_to_constant veneer

### DIFF
--- a/.cog/veneers/dashboard.common.yaml
+++ b/.cog/veneers/dashboard.common.yaml
@@ -251,10 +251,6 @@ builders:
       by_object: DashboardLink
       options: [title]
 
-  - default_to_constant:
-      by_object: Dashboard
-      options: [schemaVersion, editable]
-
 options:
   ##############
   # Dashboards #


### PR DESCRIPTION
Since all defaults are set in the constructor of each object, we don't need to set them in the builders anymore. 