### PR TITLE
Add a schema for units

### DIFF
--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -129,6 +129,10 @@ inputs:
       cue_imports:
         - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
 
+  # The schema for units
+  - cue:
+      entrypoint: '%__config_dir%/schemas/units'
+
 transformations:
   schemas:
     - '%__config_dir%/compiler/common_passes.yaml'

--- a/.cog/schemas/units/units.cue
+++ b/.cog/schemas/units/units.cue
@@ -1,0 +1,569 @@
+package units
+
+// Manually created from https://github.com/grafana/grafana/blob/d0d707895333ddbfbfe4208f8fc8bf65bf0e86e6/packages/grafana-data/src/valueFormats/categories.ts
+
+// Misc
+
+NoUnit: "none"
+Number: "none"
+String: "string"
+Short: "short"
+// SI short
+SiShort: "sishort"
+// Percent (0-100)
+Percent: "percent"
+// Percent (0.0-1.0)
+PercentUnit: "percentunit"
+// Humidity (%H)
+Humidity: "humidity"
+// Decibel (dB)
+Decibel: "dB"
+// Candela (cd)
+Candela: "candela"
+// Hexadecimal (0x)
+HexadecimalOx: "hex0x"
+Hexadecimal: "hex"
+ScientificNotation: "sci"
+LocaleFormat: "locale"
+// Pixels (px)
+Pixels: "pixel"
+
+// Acceleration: Meters/sec² (m/sec²)
+MetersSecSquared: "accMS2"
+// Acceleration: Feet/sec² (f/sec²)
+FeetSecSquared: "accFS2"
+// G unit (g)
+GUnit: "accG"
+
+// Angle: Degrees (°)
+Degrees: "degree"
+// Angle: Radians
+Radians: "radian"
+// Angle: Gradian
+Gradian: "grad"
+// Angle: Arc Minutes
+ArcMinutes: "arcmin"
+// Angle: Arc Seconds
+ArcSeconds: "arcsec"
+
+// Area: Square Meters (m²)
+SquareMeters: "areaM2"
+// Area: Square Feet (ft²)
+SquareFeet: "areaF2"
+// Area: Square Miles (mi²)
+SquareMiles: "areaMI2"
+// Area: Acres (ac)
+Acres: "acres"
+// Area: Hectares (ha)
+Hectares: "hectares"
+
+// Computation: FLOP/s
+FlopsPerSecond: "flops"
+// Computation: MFLOP/s
+MegaFlopsPerSecond: "mflops"
+// Computation: GFLOP/s
+GigaFlopsPerSecond: "gflops"
+// Computation: TFLOP/s
+TeraFlopsPerSecond: "tflops"
+// Computation: PFLOP/s
+PetaFlopsPerSecond: "pflops"
+// Computation: EFLOP/s
+ExaFlopsPerSecond: "eflops"
+// Computation: ZFLOP/s
+ZettaFlopsPerSecond: "zflops"
+// Computation: YFLOP/s
+YottaFlopsPerSecond: "yflops"
+
+// Concentration: parts-per-million (ppm)
+PartsPerMillion: "ppm"
+// Concentration: parts-per-billion (ppb)
+PartsPerBillion: "conppb"
+// Concentration: nanogram per cubic meter (ng/m³)
+NanogramPerCubicMeter: "conngm3"
+// Concentration: nanogram per normal cubic meter (ng/Nm³)
+NanogramPerNormalCubicMeter: "conngNm3"
+// Concentration: microgram per cubic meter (μg/m³)
+MicrogramPerCubicMeter: "conμgm3"
+// Concentration: microgram per normal cubic meter (μg/Nm³)
+MicrogramPerNormalCubicMeter: "conμgNm3"
+// Concentration: milligram per cubic meter (mg/m³)
+MilligramPerCubicMeter: "conmgm3"
+// Concentration: milligram per normal cubic meter (mg/Nm³)
+MilligramPerNormalCubicMeter: "conmgNm3"
+// Concentration: gram per cubic meter (g/m³)
+GramPerCubicMeter: "congm3"
+// Concentration: gram per normal cubic meter (g/Nm³)
+GramPerNormalCubicMeter: "congNm3"
+// Concentration: milligrams per decilitre (mg/dL)
+MilligramsPerDecilitre: "conmgdL"
+// Concentration: millimoles per litre (mmol/L)
+MillimolesPerLiter: "conmmolL"
+
+// Currency: Dollars ($)
+Dollars: "currencyUSD"
+// Currency: Pounds (£)
+Pounds: "currencyGBP"
+// Currency: Euro (€)
+Euro: "currencyEUR"
+// Currency: Yen (¥)
+Yen: "currencyJPY"
+// Currency: Rubles (₽)
+Rubles: "currencyRUB"
+// Currency: Hryvnias (₴)
+Hryvnias: "currencyUAH"
+// Currency: Real (R$)
+Real: "currencyBRL"
+// Currency: Danish Krone (kr)
+DanishKrone: "currencyDKK"
+// Currency: Icelandic Króna (kr)
+IcelandicKrona: "currencyISK"
+// Currency: Norwegian Krone (kr)
+NorwegianKrone: "currencyNOK"
+// Currency: Swedish Krona (kr)
+SwedishKrona: "currencySEK"
+// Currency: Czech koruna (czk)
+CzechKoruna: "currencyCZK"
+// Currency: Swiss franc (CHF)
+SwissFranc: "currencyCHF"
+// Currency: Polish Złoty (PLN)
+PolishZloty: "currencyPLN"
+// Currency: Bitcoin (฿)
+Bictoin: "currencyBTC"
+// Currency: Milli Bitcoin (฿)
+MilliBitcoin: "currencymBTC"
+// Currency: Micro Bitcoin (฿)
+MicroBitcoin: "currencyμBTC"
+// Currency: South African Rand (R)
+SouthAfricanRand: "currencyZAR"
+// Currency: Indian Rupee (₹)
+IndianRupee: "currencyINR"
+// Currency: South Korean Won (₩)
+SouthKoreanWon: "currencyKRW"
+// Currency: Indonesian Rupiah (Rp)
+IndonesianRupiah: "currencyIDR"
+// Currency: Philippine Peso (PHP)
+PhilippinePeso: "currencyPHP"
+// Currency: Vietnamese Dong (VND)
+VietnameseDong: "currencyVND"
+// Currency: Turkish Lira (₺)
+TurkishLira: "currencyTRY"
+// Currency: Malaysian Ringgit (RM)
+MalaysianRinggit: "currencyMYR"
+// Currency: CFP franc (XPF)
+CFPFranc: "currencyXPF"
+// Currency: Bulgarian Lev (BGN)
+BulgarianLev: "currencyBGN"
+// Currency: Guaraní (₲)
+Guarani: "currencyPYG"
+// Currency: Uruguay Peso (UYU)
+UruguayPeso: "currencyUYU"
+// Currency: Israeli New Shekels (₪)
+IsraeliNewShekels: "currencyILS"
+
+// Data: bytes(IEC)
+BytesIEC: "bytes"
+// Data: bytes(SI)
+BytesSI: "decbytes"
+// Data: bits(IEC)
+BitsIEC: "bits"
+// Data: bits(SI)
+BitsSI: "bydecbitstes"
+// Data: kibibytes
+Kibibytes: "kbytes"
+// Data: kilobytes
+Kilobytes: "deckbytes"
+// Data: mebibytes
+Mebibytes: "mbytes"
+// Data: megabytes
+Megabytes: "decmbytes"
+// Data: gibibytes
+Gibibytes: "gbytes"
+// Data: gigabytes
+Gigabytes: "decgbytes"
+// Data: tebibytes
+Tebibytes: "tbytes"
+// Data: terabytes
+Terabytes: "dectbytes"
+// Data: pebibytes
+Pebibytes: "pbytes"
+// Data: petabytes
+Petabytes: "decpbytes"
+
+// Data rate: packets/sec
+PacketsPerSecond: "pps"
+// Data rate: bytes/sec(IEC)
+BytesPerSecondIEC: "binBps"
+// Data rate: bytes/sec(SI)
+BytesPerSecondSI: "Bps"
+// Data rate: bits/sec(IEC)
+BitsPerSecondIEC: "binbps"
+// Data rate: bits/sec(SI)
+BitsPerSecondSI: "bps"
+// Data rate: kibibytes/sec
+KibibytesPerSecond: "KiBs"
+// Data rate: kibibits/sec
+KibibitsPerSecond: "Kibits"
+// Data rate: kilobytes/sec
+KilobytesPerSecond: "KBs"
+// Data rate: kilobits/sec
+KilobitsPerSecond: "Kbits"
+// Data rate: mebibytes/sec
+MebibytesPerSecond: "MiBs"
+// Data rate: mebibits/sec
+MebibitsPerSecond: "Mibits"
+// Data rate: megabytes/sec
+MegabytesPerSecond: "MBs"
+// Data rate: megabits/sec
+MegabitsPerSecond: "Mbits"
+// Data rate: gibibytes/sec
+GibibytesPerSecond: "GiBs"
+// Data rate: gibibits/sec
+GibibitsPerSecond: "Gibits"
+// Data rate: gigabytes/sec
+GigabytesPerSecond: "GBs"
+// Data rate: gigabits/sec
+GigabitsPerSecond: "Gbits"
+// Data rate: tebibytes/sec
+TebibytesPerSecond: "TiBs"
+// Data rate: tebibits/sec
+TebibitsPerSecond: "Tibits"
+// Data rate: terabytes/sec
+TerabytesPerSecond: "TBs"
+// Data rate: terabits/sec
+TerabitsPerSecond: "Tbits"
+// Data rate: pebibytes/sec
+PebibytesPerSecond: "PiBs"
+// Data rate: pebibits/sec
+PebibitsPerSecond: "Pibits"
+// Data rate: petabytes/sec
+PetabytesPerSecond: "PBs"
+// Data rate: petabits/sec
+PetabitsPerSecond: "Pbits"
+
+// Date & time: Datetime ISO
+DatetimeISO: "dateTimeAsIso"
+// Date & time: Datetime ISO (No date if today)
+DatetimeISONotToday: "dateTimeAsIsoNoDateIfToday"
+// Date & time: Datetime US
+DatetimeUS: "dateTimeAsUS"
+// Date & time: Datetime US (No date if today)
+DatetimeUSNotToday: "dateTimeAsUSNoDateIfToday"
+// Date & time: Datetime local
+DatetimeLocal: "dateTimeAsLocal"
+// Date & time: Datetime local (No date if today)
+DatetimeLocalNotToday: "dateTimeAsLocalNoDateIfToday"
+// Date & time: Datetime default
+DatetimeDefault: "dateTimeAsSystem"
+// Date & time: From Now
+DateTimeFromNow: "dateTimeFromNow"
+
+// Energy: Watt (W)
+Watt: "watt"
+// Energy: Kilowatt (kW)
+KiloWatt: "kwatt"
+// Energy: Megawatt (MW)
+MegaWatt: "megwatt"
+// Energy: Gigawatt (GW)
+GigaWatt: "gwatt"
+// Energy: Milliwatt (mW)
+MilliWatt: "mwatt"
+// Energy: Watt per square meter (W/m²)
+WattPerSquareMeter: "Wm2"
+// Energy: Volt-Ampere (VA)
+VoltAmpere: "voltamp"
+// Energy: Kilovolt-Ampere (kVA)
+KiloVoltAmpere: "kvoltamp"
+// Energy: Volt-Ampere reactive (VAr)
+VoltAmpereReactive: "voltampreact"
+// Energy: Kilovolt-Ampere reactive (kVAr)
+KiloVoltAmpereReactive: "kvoltampreact"
+// Energy: Watt-hour (Wh)
+WattHour: "watth"
+// Energy: Watt-hour per Kilogram (Wh/kg)
+WattHourPerKilogram: "watthperkg"
+// Energy: Kilowatt-hour (kWh)
+KiloWattHour: "kwatth"
+// Energy: Kilowatt-min (kWm)
+KiloWattMinute: "kwattm"
+// Energy: Megawatt-hour (MWh)
+MegaWattHour: "mwatth"
+// Energy: Ampere-hour (Ah)
+AmpereHour: "amph"
+// Energy: Kiloampere-hour (kAh)
+KiloAmpereHour: "kamph"
+// Energy: Milliampere-hour (mAh)
+MilliAmpereHour: "mamph"
+// Energy: Joule (J)
+Joule: "joule"
+// Energy: Electron volt (eV)
+ElectronVolt: "ev"
+// Energy: Ampere (A)
+Ampere: "amp"
+// Energy: Kiloampere (kA)
+KiloAmpere: "kamp"
+// Energy: Milliampere (mA)
+MilliAmpere: "mamp"
+// Energy: Volt (V)
+Volt: "volt"
+// Energy: Kilovolt (kV)
+KiloVolt: "kvolt"
+// Energy: Millivolt (mV)
+MilliVolt: "mvolt"
+// Energy: Decibel-milliwatt (dBm)
+DecibelMilliWatt: "dBm"
+// Energy: Milliohm (mΩ)
+MilliOhm: "mohm"
+// Energy: Ohm (Ω)
+Ohm: "ohm"
+// Energy: Kiloohm (kΩ)
+KiloOhm: "kohm"
+// Energy: Megaohm (MΩ)
+MegaOhm: "Mohm"
+// Energy: Farad (F)
+Farad: "farad"
+// Energy: Microfarad (µF)
+MicroFarad: "watt"
+// Energy: Nanofarad (nF)
+NanoFarad: "nfarad"
+// Energy: Picofarad (pF)
+PicoFarad: "pfarad"
+// Energy: Femtofarad (fF)
+FemtoFarad: "ffarad"
+// Energy: Henry (H)
+Henry: "henry"
+// Energy: Millihenry (mH)
+MilliHenry: "mhenry"
+// Energy: Microhenry (µH)
+MicroHenry: "µhenry"
+// Energy: Lumens (Lm)
+Lumens: "lumens"
+
+// Flow: Gallons/min (gpm)
+GallonsPerMinute: "flowgpm"
+// Flow: Cubic meters/sec (cms)
+CubicMetersPerSecond: "flowcms"
+// Flow: Cubic feet/sec (cfs)
+CubicFeetPerSecond: "flowcms"
+// Flow: Cubic feet/min (cfm)
+CubicFeetPerMinute: "flowcms"
+// Flow: Litre/hour
+LitrePerHour: "litreh"
+// Flow: Litre/min (L/min)
+LitrePerMinute: "flowlpm"
+// Flow: milliLitre/min (mL/min)
+MilliLitrePerMinute: "flowmlpm"
+// Flow: Lux (lx)
+Lux: "lux"
+
+// Force: Newton-meters (Nm)
+NewtonMeters: "forceNm"
+// Force: Kilonewton-meters (kNm)
+KiloNewtonMeters: "forcekNm"
+// Force: Newtons (N)
+Newtons: "forceN"
+// Force: Kilonewtons (kN)
+KiloNewtons: "forcekN"
+
+// Hash rate: hashes/sec
+HashesPerSecond: "Hs"
+// Hash rate: kilohashes/sec
+KiloHashesPerSecond: "KHs"
+// Hash rate: megahashes/sec
+MegaHashesPerSecond: "MHs"
+// Hash rate: gigahashes/sec
+GigaHashesPerSecond: "GHs"
+// Hash rate: terahashes/sec
+TeraHashesPerSecond: "THs"
+// Hash rate: petahashes/sec
+PetaHashesPerSecond: "PHs"
+// Hash rate: exahashes/sec
+ExaHashesPerSecond: "EHs"
+
+// Mass: milligram (mg)
+Milligram: "massmg"
+// Mass: gram (g)
+Gram: "massg"
+// Mass: pound (lb)
+Pound: "masslb"
+// Mass: kilogram (kg)
+Kilogram: "masskg"
+// Mass: metric ton (t)
+MetricTon: "masst"
+
+// Length: millimeter (mm)
+Millimeter: "lengthmm"
+// Length: inch (in)
+Inch: "lengthin"
+// Length: feet (ft)
+Feet: "lengthft"
+// Length: meter (m)
+Meter: "lengthm"
+// Length: kilometer (km)
+Kilometer: "lengthkm"
+// Length: mile (mi)
+Mile: "lengthmi"
+
+// Pressure: Millibars
+Millibars: "pressurembar"
+// Pressure: Bars
+Bars: "pressurebar"
+// Pressure: Kilobars
+Kilobars: "pressurekbar"
+// Pressure: Pascals
+Pascals: "pressurepa"
+// Pressure: Hectopascals
+Hectopascals: "pressurehpa"
+// Pressure: Kilopascals
+Kilopascals: "pressurekpa"
+// Pressure: Inches of mercury
+InchesOfMercury: "pressurehg"
+// Pressure: PSI
+PSI: "pressurepsi"
+
+// Radiation: Becquerel (Bq)
+Becquerel: "radbq"
+// Radiation: curie (Ci)
+Curie: "radci"
+// Radiation: Gray (Gy)
+Gray: "radgy"
+// Radiation: rad
+Rad: "radrad"
+// Radiation: Sievert (Sv)
+Sievert: "radsv"
+// Radiation: milliSievert (mSv)
+Millisievert: "radmsv"
+// Radiation: microSievert (µSv)
+Microsievert: "radusv"
+// Radiation: rem
+Rem: "radrem"
+// Radiation: Exposure (C/kg)
+Exposure: "radexpckg"
+// Radiation: roentgen (R)
+Roentgen: "radr"
+// Radiation: Sievert/hour (Sv/h)
+SievertPerHour: "radsvh"
+// Radiation: milliSievert/hour (mSv/h)
+MillisievertPerHour: "radmsvh"
+// Radiation: microSievert/hour (µSv/h)
+MicrosievertPerHour: "radusvh"
+
+// Rotational Speed: Revolutions per minute (rpm)
+RevolutionsPerMinute: "rotrpm"
+// Rotational Speed: Hertz (Hz)
+HertzRotation: "rothz"
+// Rotational Speed: Kilohertz (kHz)
+KilohertzRotation: "rotkhz"
+// Rotational Speed: Megahertz (MHz)
+MegahertzRotation: "rotmhz"
+// Rotational Speed: Gigahertz (GHz)
+GigahertzRotation: "rotghz"
+// Rotational Speed: Radians per second (rad/s)
+RadiansPerSecond: "rotrads"
+// Rotational Speed: Degrees per second (°/s)
+DegreesPerSecond: "rotdegs"
+
+// Temperature: Celsius (°C)
+Celsius: "celsius"
+// Temperature: Fahrenheit (°F)
+Fahrenheit: "fahrenheit"
+// Temperature: Kelvin (K)
+Kelvin: "kelvin"
+
+// Time: Hertz (1/s)
+Hertz: "hertz"
+// Time: nanoseconds (ns)
+Nanoseconds: "ns"
+// Time: microseconds (µs)
+Microseconds: "µs"
+// Time: milliseconds (ms)
+Milliseconds: "ms"
+// Time: seconds (s)
+Seconds: "s"
+// Time: minutes (m)
+Minutes: "m"
+// Time: hours (h)
+Hours: "h"
+// Time: days (d)
+Days: "d"
+// Time: duration (ms)
+DurationMilliseconds: "dtdurationms"
+// Time: duration (s)
+DurationSeconds: "dtdurations"
+// Time: duration (hh:mm:ss)
+DurationInHoursMinutesSeconds: "dthms"
+// Time: duration (d hh:mm:ss)
+DurationInDaysHoursMinutesSeconds: "dtdhms"
+// Time: Timeticks (s/100)
+Timeticks: "timeticks"
+// Time: clock (ms)
+ClockMilliseconds: "clockms"
+// Time: clock (s)
+ClockSeconds: "clocks"
+
+// Throughput: counts/sec (cps)
+CountsPerSecond: "cps"
+// Throughput: ops/sec (ops)
+OpsPerSecond: "ops"
+// Throughput: requests/sec (rps)
+RequestsPerSecond: "reqps"
+// Throughput: reads/sec (rps)
+ReadsPerSecond: "rps"
+// Throughput: writes/sec (wps)
+WritesPerSecond: "wps"
+// Throughput: I/O ops/sec (iops)
+IOOpsPerSecond: "iops"
+// Throughput: events/sec (eps)
+EventsPerSecond: "eps"
+// Throughput: messages/sec (mps)
+MessagesPerSecond: "mps"
+// Throughput: records/sec (rps)
+RecordsPerSecond: "recps"
+// Throughput: rows/sec (rps)
+RowsPerSecond: "rowsps"
+// Throughput: counts/min (cpm)
+CountsPerMinute: "cpm"
+// Throughput: ops/min (opm)
+OpsPerMinute: "opm"
+// Throughput: requests/min (rpm)
+RequestsPerMinute: "reqpm"
+// Throughput: reads/min (rpm)
+ReadsPerMinute: "rpm"
+// Throughput: writes/min (wpm)
+WritesPerMinute: "wpm"
+// Throughput: events/min (epm)
+EventsPerMinute: "epm"
+// Throughput: messages/min (mpm)
+MessagesPerMinute: "mpm"
+// Throughput: records/min (rpm)
+RecordsPerMinute: "recpm"
+// Throughput: rows/min (rpm)
+RowsPerMinute: "rowspm"
+
+// Velocity: meters/second (m/s)
+MetersPerSecond: "velocityms"
+// Velocity: kilometers/hour (km/h)
+KilometersPerHour: "velocitykmh"
+// Velocity: miles/hour (mph)
+MilesPerHour: "velocitymph"
+// Velocity: knot (kn)
+Knot: "velocityknot"
+
+// Volume: millilitre (mL)
+Millilitre: "mlitre"
+// Volume: litre (L)
+Litre: "litre"
+// Volume: cubic meter
+CubicMeter: "m3"
+// Volume: Normal cubic meter
+NormalCubicMeter: "Nm3"
+// Volume: cubic decimeter
+CubicDecimeter: "dm3"
+// Volume: gallons
+Gallons: "gallons"
+
+// Boolean: True / False
+Bool: "bool"
+// Boolean: Yes / No
+BoolYesNo: "bool_yes_no"
+// Boolean: On / Off
+BoolOnOff: "bool_on_off"


### PR DESCRIPTION
Closes #649

Adds a schema for known units, as [described in Grafana](https://github.com/grafana/grafana/blob/d0d707895333ddbfbfe4208f8fc8bf65bf0e86e6/packages/grafana-data/src/valueFormats/categories.ts).

These units are defined as constants as opposed to a hypothetical `Unit` enum since Grafana allows for [custom units](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-standard-options/#custom-units)