### PR TITLE
Manually define missing objects in the alerting schema

### DIFF
--- a/.cog/compiler/alerting.yaml
+++ b/.cog/compiler/alerting.yaml
@@ -27,6 +27,121 @@ passes:
   - rename_object:
       from: alerting.MuteTimeInterval
       to: MuteTiming
+  - add_object:
+      object: alerting.TimeInterval
+      as:
+        kind: struct
+        struct:
+          fields:
+            - name: times
+              type:
+                kind: array
+                array:
+                  value_type:
+                    kind: ref
+                    ref: { referred_pkg: alerting, referred_type: TimeRange }
+            - name: weekdays
+              type:
+                kind: array
+                array:
+                  value_type:
+                    kind: ref
+                    ref: { referred_pkg: alerting, referred_type: WeekdayRange }
+            - name: days_of_month
+              type:
+                kind: array
+                array:
+                  value_type:
+                    kind: ref
+                    ref: { referred_pkg: alerting, referred_type: DayOfMonthRange }
+            - name: months
+              type:
+                kind: array
+                array:
+                  value_type:
+                    kind: ref
+                    ref: { referred_pkg: alerting, referred_type: MonthRange }
+            - name: years
+              type:
+                kind: array
+                array:
+                  value_type:
+                    kind: ref
+                    ref: { referred_pkg: alerting, referred_type: YearRange }
+            - name: location
+              type:
+                kind: ref
+                ref: { referred_pkg: alerting, referred_type: Location }
+  - add_object:
+      object: alerting.WeekdayRange
+      as:
+        kind: struct
+        struct:
+          fields:
+            - name: begin
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+            - name: end
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+  - add_object:
+      object: alerting.DayOfMonthRange
+      as:
+        kind: struct
+        struct:
+          fields:
+            - name: begin
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+            - name: end
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+  - add_object:
+      object: alerting.YearRange
+      as:
+        kind: struct
+        struct:
+          fields:
+            - name: begin
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+            - name: end
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+  - add_object:
+      object: alerting.MonthRange
+      as:
+        kind: struct
+        struct:
+          fields:
+            - name: begin
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+            - name: end
+              type:
+                kind: scalar
+                scalar:
+                  scalar_kind: int32
+  - add_object:
+      object: alerting.Location
+      as:
+        kind: scalar
+        scalar:
+          scalar_kind: string
 
   - retype_field:
       field: alerting.Query.model

--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -54,7 +54,7 @@ inputs:
         - Route
         - MuteTimeInterval
         - NotificationTemplate
-        - TimeIntervalItem
+        - TimeRange
       transformations:
         - '%__config_dir%/compiler/alerting.yaml'
 


### PR DESCRIPTION
Adds a few objects required for alerting but missing in the original schema.

These objects relate to the definition of `MuteTimeInterval` (sets of time intervals during which an alerting route should be muted).

Note: being unable to generate the diff is expected as main is borked.