### PR TITLE
Go: Handle panels without grid position set

### DIFF
--- a/.cog/templates/go/overrides/assignment_Dashboard_withRow.tmpl
+++ b/.cog/templates/go/overrides/assignment_Dashboard_withRow.tmpl
@@ -22,8 +22,8 @@
 	// Position the row's panels on the grid
 	for _, panel := range rowPanelResource.Panels {
 		// If the panel does not have a GridPos set, set it to the default one.
-		if panelResource.GridPos == nil {
-			panelResource.GridPos = NewGridPos()
+		if panel.GridPos == nil {
+			panel.GridPos = NewGridPos()
 		}
 
 		// The panel either has no position set, or it is the first panel of the dashboard.

--- a/.cog/templates/go/overrides/assignment_Dashboard_withRow.tmpl
+++ b/.cog/templates/go/overrides/assignment_Dashboard_withRow.tmpl
@@ -21,10 +21,10 @@
 
 	// Position the row's panels on the grid
 	for _, panel := range rowPanelResource.Panels {
-        // If the panel does not have a GridPos set, set it to the default one.
-        if panelResource.GridPos == nil {
-            panelResource.GridPos = NewGridPos()
-        }
+		// If the panel does not have a GridPos set, set it to the default one.
+		if panelResource.GridPos == nil {
+			panelResource.GridPos = NewGridPos()
+		}
 
 		// The panel either has no position set, or it is the first panel of the dashboard.
 		// In that case, we position it on the grid

--- a/.cog/templates/go/overrides/assignment_Dashboard_withRow.tmpl
+++ b/.cog/templates/go/overrides/assignment_Dashboard_withRow.tmpl
@@ -21,6 +21,11 @@
 
 	// Position the row's panels on the grid
 	for _, panel := range rowPanelResource.Panels {
+        // If the panel does not have a GridPos set, set it to the default one.
+        if panelResource.GridPos == nil {
+            panelResource.GridPos = NewGridPos()
+        }
+
 		// The panel either has no position set, or it is the first panel of the dashboard.
 		// In that case, we position it on the grid
 		if panel.GridPos.X == 0 && panel.GridPos.Y == 0 {


### PR DESCRIPTION
## Description

If the `Panel` in a `Row` doesn't have explicitly set `GridPos`, it will result in a `panic`.

It works correctly if there's no `Row`. The `Panel` already have the same logic ([code here](https://github.com/grafana/grafana-foundation-sdk/blob/97df87a4aa009680bee64e9cb243e17022d9e573/.cog/templates/go/overrides/assignment_Dashboard_withPanel.tmpl))

### Minimal example

```go
package main

import (
	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
)

func main() {
	row := dashboard.NewRowBuilder("Test Row")
	panel := timeseries.NewPanelBuilder().Title("Test Panel")
	dashboard.NewDashboardBuilder("Test Dashboard").WithRow(row.WithPanel(panel))
}
```

Results in 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x100b3e77c]

goroutine 1 [running]:
github.com/grafana/grafana-foundation-sdk/go/dashboard.(*DashboardBuilder).WithRow(0x14000120040, {0x100b9d528, 0x14000128020})
	/go/pkg/mod/github.com/grafana/grafana-foundation-sdk/go@v0.0.0-20250501220944-e22983a17bec/dashboard/dashboard_builder_gen.go:245 +0x31c
main.main()
	/grafana-dashboard/clickhouse/main.go:11 +0x258
```