### PR TITLE
Relocate 'com.fasterxml.jackson', 'com.grafana.relocated.jackson'

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -20,6 +20,7 @@ java {
 shadowJar {
     // allows maven to read the artifact (by default, it's "plain")
     archiveClassifier.set('')
+    relocate 'com.fasterxml.jackson', 'com.grafana.relocated.jackson'
 }
 
 allprojects {


### PR DESCRIPTION
We are looking to use this SDK within a monorepo where we have jackson databind's version pinned for the whole monorepo. By not shadowing the jackson version, the grafana sdk is causing dependency conflicts within the repo as we try to bump versions. The simple fix should be to shadow the dependency. 