### PR TITLE
Relocate 'com.fasterxml.jackson', 'com.grafana.relocated.jackson'

### DIFF
--- a/.cog/templates/java/extra/build.gradle
+++ b/.cog/templates/java/extra/build.gradle
@@ -22,6 +22,7 @@ java {
 shadowJar {
     // allows maven to read the artifact (by default, it's "plain")
     archiveClassifier.set('')
+    relocate 'com.fasterxml.jackson', 'com.grafana.relocated.jackson'
 }
 
 allprojects {


### PR DESCRIPTION
We are looking to use this SDK within a monorepo where we have jackson databind's version pinned for the whole monorepo. By not shadowing the jackson version, the grafana sdk is causing dependency conflicts within the repo as we try to bump versions. The simple fix should be to shadow the dependency.

This PR performs this change on the correct branch and closes out https://github.com/grafana/grafana-foundation-sdk/pull/756