### PR TITLE
Java: Update shadow library

### DIFF
--- a/.cog/templates/java/extra/build.gradle
+++ b/.cog/templates/java/extra/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'org.jreleaser' version '1.18.0'
     {{- end }}
     id 'signing'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.6'
 }
 
 group = "com.grafana"


### PR DESCRIPTION
The current version of shadow library generates an error using relocate directive. Looks like that the library isn't updated and it was transferred into a new project. (I think that it should be enough...)