### PR TITLE
Java: Add write workflow permissions for CI

### DIFF
--- a/.cog/repository_templates/java/.github/workflows/java-release.tmpl
+++ b/.cog/repository_templates/java/.github/workflows/java-release.tmpl
@@ -14,6 +14,7 @@ jobs:
 
     permissions:
       contents: read
+      workflows: write
 
     defaults:
       run:
@@ -21,7 +22,7 @@ jobs:
         working-directory: ./java
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Uses Java SDK {{ `${{ env.JAVA_VERSION }}` }}
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #v4.7.1

--- a/.cog/repository_templates/python/.github/workflows/python-release.tmpl
+++ b/.cog/repository_templates/python/.github/workflows/python-release.tmpl
@@ -26,7 +26,7 @@ jobs:
         working-directory: ./python
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Python {{ `${{ env.PYTHON_VERSION }}` }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
It seems that JReleaser needs workflow write permission in the CI. [Error](https://github.com/grafana/grafana-foundation-sdk/actions/runs/15439535496/job/43453854799#step:5:197)