### PR TITLE
Java: Disable Github publishing

### DIFF
--- a/.cog/repository_templates/java/.github/workflows/java-release.tmpl
+++ b/.cog/repository_templates/java/.github/workflows/java-release.tmpl
@@ -14,7 +14,6 @@ jobs:
 
     permissions:
       contents: read
-      workflows: write
 
     defaults:
       run:

--- a/.cog/templates/java/extra/build.gradle
+++ b/.cog/templates/java/extra/build.gradle
@@ -109,6 +109,12 @@ publishing {
 }
 
 jreleaser {
+  release {
+    github {
+      enabled = false
+      skipRelease = true
+    }
+  }
   signing {
     active = 'ALWAYS'
     armored = true


### PR DESCRIPTION
Java release was failing because JReleaser needs permissions to publish artifacts in Github but we don't want to publish anything since we are working only with branches.

So we have to disable github publications in jreleaser and we don't need workflow permission.