### PR TITLE
Java: Add missing CI configuration

### DIFF
--- a/.cog/repository_templates/java/.github/workflows/java-release.tmpl
+++ b/.cog/repository_templates/java/.github/workflows/java-release.tmpl
@@ -53,9 +53,9 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: {{ `${{ env.GPG_PASSPHRASE }}` }}
           JRELEASER_GPG_PUBLIC_KEY: {{ `${{ env.GPG_PUBLIC_KEY }}` }}
           JRELEASER_GPG_SECRET_KEY: {{ `${{ env.GPG_PRIVATE_KEY }}` }}
-        run:
-          gradle jreleaserConfig
+          JRELEASER_MAVENCENTRAL_STAGE: 'FULL'
+        run: |
           gradle clean
           gradle publish
-          gradle jreleaserFullRelease
+          gradle jreleaserDeploy
   

--- a/.cog/templates/java/extra/build.gradle
+++ b/.cog/templates/java/extra/build.gradle
@@ -109,6 +109,15 @@ publishing {
 }
 
 jreleaser {
+  release {
+    github {
+      enabled = false
+      skipRelease = true
+    }
+  }
+  announce {
+    enabled = false
+  }
   signing {
     active = 'ALWAYS'
     armored = true
@@ -116,24 +125,25 @@ jreleaser {
   deploy {
     maven {
       mavenCentral {
-        'release-deploy' {
+        mavenCentralRelease {
           active = 'RELEASE'
           url = 'https://central.sonatype.com/api/v1/publisher'
-          stagingRepository('target/staging-deploy')
+          stagingRepository('build/staging-deploy')
         }
-      }
-      nexus2 {
-        'snapshot-deploy' {
+        mavenCentralSnapshot {
           active = 'SNAPSHOT'
-          snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots'
-          applyMavenCentralRules = true
+          url = 'https://central.sonatype.com/repository/maven-snapshots'
           snapshotSupported = true
-          closeRepository = true
-          releaseRepository = true
-          stagingRepository('target/staging-deploy')
+          stagingRepository('build/staging-deploy')
         }
       }
     }
   }
+}
+
+tasks.withType(org.jreleaser.gradle.plugin.tasks.JReleaserConfigTask).configureEach {
+    dryrun = false
+    gitRootSearch = true
+    strict = false
 }
 {{- end }}


### PR DESCRIPTION
Looks like that we have to disable more features that are enabled by default like `announce` (that publish in Github too). Repositories configuration were wrong. For snapshots and maven the config, we only have to setup the urls and `snapshotSupported = true` for snapshots.

In the java-release file, the changes are:
* `JRELEASER_MAVENCENTRAL_STAGE: 'FULL'`: It publish to snapshot and maven central (both)
* Remove `gradle jreleaserConfig`, since it adds a check that isn't necessary.
* `jreleaserFullRelease` tries to publish to Github internally. Changed with `jreleaserDeploy` that only does to Maven.
* `gradle clean` and `gradle publish`, cleans and publish the project internally to `build/staging-deploy` and its going to be used by `jreleaserDeploy`, getting the information with `stagingRepository('build/staging-deploy')`