### PR TITLE
CI: Use Github App to add workflow permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@75804962c1ba608148988c1e2dc35fbb0ee21746
         with:
           repo_secrets: |
-            GITHUB_APP_ID=github_pp:app-id
+            GITHUB_APP_ID=github_app:app-id
             GITHUB_APP_PRIVATE_KEY=github_app:private-key
 
       - name: Generate github private token

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,11 +56,26 @@ jobs:
           enable-cache: 'true'
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
+      - name: Get secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@75804962c1ba608148988c1e2dc35fbb0ee21746
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=github_pp:app-id
+            GITHUB_APP_PRIVATE_KEY=github_app:private-key
+
+      - name: Generate github private token
+        id: generate_github_token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Run the release script
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${{ env.GENERATED_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
 
           if [ "${VERSION_TARGET}" == "all" ]; then
             devbox run ./scripts/release-all.sh
@@ -75,3 +90,4 @@ jobs:
           DRY_RUN: ${{ inputs.dryRun == true && 'yes' || 'no' }}
           SKIP_VALIDATION: ${{ inputs.skipValidation == true && 'yes' || 'no' }}
           VERSION_TARGET: ${{ inputs.version }}
+          GENERATED_GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}


### PR DESCRIPTION
Cotributes to: https://github.com/grafana/grafana-foundation-sdk/issues/766

Changing the template extension from `yaml` to `tmpl` to avoid zizmor issues in the CI seems that its detected as a "workflow change". Its one of the reason of release fails 🤷🏼‍♀️.

So an option is to use a private GithubApp with a token with extra permissions that should allows us to create the release. 