### PR TITLE
CI: Add id-token for retrieve vault secrets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ permissions:
   contents: write # to push new branches
   actions: write # new branches will contain github actions
   pull-requests: write # to open PRs
+  id-token: write # to retrieve vault secrets
 
 # Allow only one concurrent release, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these releases to complete.


### PR DESCRIPTION
Retrieve secrets requires `id-token` permission