### PR TITLE
CI: Add missing id-token permission for java secrets

### DIFF
--- a/.cog/repository_templates/java/.github/workflows/java-release.tmpl
+++ b/.cog/repository_templates/java/.github/workflows/java-release.tmpl
@@ -14,6 +14,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     defaults:
       run:


### PR DESCRIPTION
Java workflow needs `id-token` permission to retrieve the secrets.