### PR TITLE
CI: Add Java CI failure step

### DIFF
--- a/.cog/repository_templates/java/.github/workflows/java-release.tmpl
+++ b/.cog/repository_templates/java/.github/workflows/java-release.tmpl
@@ -65,7 +65,7 @@ jobs:
         if: failure()
         run: |
           echo "Dumping build result file (if exists):"
-          FILE=$(find ${{ runner.temp }}/.gradle-actions/build-results -name '__run-*.json' | sort | tail -n 1)
+          FILE=$(find {{ `${{ runner.temp }}` }}/.gradle-actions/build-results -name '__run-*.json' | sort | tail -n 1)
           if [ -f "$FILE" ]; then
             echo "File: $FILE"
             cat "$FILE"

--- a/.cog/repository_templates/java/.github/workflows/java-release.tmpl
+++ b/.cog/repository_templates/java/.github/workflows/java-release.tmpl
@@ -61,3 +61,14 @@ jobs:
           gradle publish
           gradle jreleaserDeploy
   
+      - name: Show Gradle Action build result (if exists)
+        if: failure()
+        run: |
+          echo "Dumping build result file (if exists):"
+          FILE=$(find ${{ runner.temp }}/.gradle-actions/build-results -name '__run-*.json' | sort | tail -n 1)
+          if [ -f "$FILE" ]; then
+            echo "File: $FILE"
+            cat "$FILE"
+          else
+            echo "No build result file found."
+          fi


### PR DESCRIPTION
When JReleaser fails, it creates a temporal file with the information to see what happened. So this step prints it in the console.