### PR TITLE
Remove Default collapsed==true in RowBuilder

### DIFF
--- a/java/src/main/java/com/grafana/foundation/dashboard/RowBuilder.java
+++ b/java/src/main/java/com/grafana/foundation/dashboard/RowBuilder.java
@@ -38,12 +38,11 @@ public class RowBuilder implements com.grafana.foundation.cog.Builder<RowPanel> 
     }
     
     public RowBuilder withPanel(com.grafana.foundation.cog.Builder<Panel> panel) {
-		if (this.internal.panels == null) {
-			this.internal.panels = new LinkedList<>();
-		}
-    Panel panelResource = panel.build();
+       if (this.internal.panels == null) {
+	       this.internal.panels = new LinkedList<>();
+       }
+	Panel panelResource = panel.build();
         this.internal.panels.add(panelResource);
-        this.internal.collapsed = true;
         return this;
     }
     


### PR DESCRIPTION
I was having an issue where the collapsed setting I was setting on a RowBuilder was constantly being overwritten to `true`, and turns out this was the reason. I'm not sure if there's a good reason to want to have a collapsed setting set to `true` when a Panel is added, since that's establishing it for the entire RowPanel. 