### PR TITLE
make code content copyable in docs

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -52,6 +52,7 @@ theme:
     - navigation.top
     - navigation.prune
     - search.highlight
+    - content.code.copy
 
   custom_dir: overrides
 


### PR DESCRIPTION
Add `copy to clipboard` button for code content in docs like -

<img width="2954" height="1174" alt="Screenshot 2025-07-24 at 2 18 30 AM" src="https://github.com/user-attachments/assets/1e3f5b36-207b-4b6d-a4e4-fd08879be511" />
