### PR TITLE
Minor cleanup to alert-rule example

### DIFF
--- a/examples/go/alert-rule/main.go
+++ b/examples/go/alert-rule/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	datasourceUid := "DS_PROMETHEUS_UID"
-	ruleGroupUid := "1m"
+	ruleGroupTitle := "example-group"
 	folderUid := "folder-foo-uid"
 
 	queryA := alerting.NewQueryBuilder("A").
@@ -48,12 +48,12 @@ func main() {
 		ExecErrState(alerting.RuleExecErrStateError).
 		NoDataState(alerting.RuleNoDataStateNoData).
 		For("0m").
-		RuleGroup(ruleGroupUid).
+		RuleGroup(ruleGroupTitle).
 		FolderUID(folderUid).
 		Labels(map[string]string{"severity": "critical"}).
 		Annotations(map[string]string{"summary": "Demo rule"})
 
-	ruleGroupBuilder := alerting.NewRuleGroupBuilder(ruleGroupUid).
+	ruleGroupBuilder := alerting.NewRuleGroupBuilder(ruleGroupTitle).
 		Interval(60).
 		FolderUid(folderUid).
 		Rules([]cog.Builder[alerting.Rule]{ruleBuilder})


### PR DESCRIPTION
The ruleGroupUid variable naming is a confusing, and is set to an odd value
that looks like a duration (1m). Rename it and give it a more sensible string.
