### PR TITLE
Bump cog version to v0.0.40

### DIFF
--- a/.github/actions/setup-cog/action.yaml
+++ b/.github/actions/setup-cog/action.yaml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "Cog version to install"
     required: true
-    default: "0.0.39"
+    default: "0.0.40"
 outputs:
   bin-path:
     description: "Path to the cog binary"


### PR DESCRIPTION
It updates cog version to ~v0.0.39~ v0.0.40 (It has a fix for Java serializers/deserializers)

Depends of: https://github.com/grafana/cog/pull/845