### PR TITLE
Migrate NPM token to OIDC

### DIFF
--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -16,6 +16,10 @@ jobs:
       contents: read
       id-token: write
 
+    environment:
+      name: typescript
+      url: https://www.npmjs.com/package/@grafana/grafana-foundation-sdk
+
     defaults:
       run:
         shell: bash
@@ -38,14 +42,8 @@ jobs:
 
       - name: Build
         run: yarn build
-        
-      - name: Get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@75804962c1ba608148988c1e2dc35fbb0ee21746
-        with:
-          repo_secrets: |
-            NPM_TOKEN=secrets:npm_token
 
       - name: Publish to NPM registry
         run: yarn publish --access public
         env:
-          NODE_AUTH_TOKEN: {{ `${{ env.NPM_TOKEN }}` }}
+          NODE_AUTH_TOKEN: {{ `${{ secrets.NPM_READ_TOKEN }}` }}

--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -38,10 +38,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: yarn install
+        run: npm ci
 
       - name: Build
-        run: yarn build
+        run: npm run build
 
       - name: Publish to NPM registry
-        run: yarn publish --access public
+        run: npm publish --access public

--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -45,5 +45,3 @@ jobs:
 
       - name: Publish to NPM registry
         run: yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: {{ `${{ secrets.NPM_READ_TOKEN }}` }}


### PR DESCRIPTION
It migrates NPM token to OIDC, it requires create an environment and some configuration in the npm package settings (already done) to be able to retrieve the NPM token without specify it in the CI.