### PR TITLE
Fix npm dependency installation

### DIFF
--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -38,7 +38,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
I followed the documentation and `npm ci` only works when we have package.json.lock file. Because the library is autogenerated, we don't have this file making the installation to fail. So `npm install` should be the correct command.