### PR TITLE
Update npm to latest version

### DIFF
--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -5,7 +5,7 @@ on:
       - '{{ .Extra.ReleaseBranch|replace "+" "\\+" }}'
 
 env:
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
 
 jobs:
   release:
@@ -36,6 +36,9 @@ jobs:
           node-version: {{ `${{ env.NODE_VERSION }}` }}
           scope: '@grafana'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm latest version
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Publishing to OIDC needs at least NPM `v11.5.1` and ubuntu-latest uses `v10.8.2`.