### PR TITLE
Npm release tag

### DIFF
--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -47,4 +47,4 @@ jobs:
         run: npm run build
 
       - name: Publish to NPM registry
-        run: npm publish --access public --tag v{{ .Extra.GrafanaVersion|registryToSemver }}
+        run: npm publish --access public --tag {{ .Extra.GrafanaVersion }}


### PR DESCRIPTION
New npm version detects the branch version as a "pre-release" and it forces us to put a `--tag`. 

So this change adds the Grafana version as tag. 🤞🏼.