### PR TITLE
Fix invalid tag

### DIFF
--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -47,4 +47,4 @@ jobs:
         run: npm run build
 
       - name: Publish to NPM registry
-        run: npm publish --access public --tag {{ .Extra.GrafanaVersion }}
+        run: npm publish --access public --tag {{ .Extra.GrafanaVersion }}-latest


### PR DESCRIPTION
It seems that we cannot use "semver" version only as tag. It adds `latest` at the end to fix that.