### PR TITLE
Add new output parameter to setup NPM tag

### DIFF
--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -11,6 +11,7 @@ parameters:
   cog_version: 'v0.0.x'
   release_branch: 'release_branch'
   build_timestamp: 'build_timestamp'
+  typescript_tag: '10-4-latest'
   go_package_root: 'github.com/grafana/grafana-foundation-sdk/go'
   java_package_path: 'com.grafana.foundation'
   php_namespace_root: 'Grafana\Foundation'
@@ -160,6 +161,7 @@ output:
     CogVersion: '%cog_version%'
     ReleaseBranch: '%release_branch%'
     BuildTimestamp: '%build_timestamp%'
+    TypescriptTag: '%typescript_tag%'
   output_options:
     replace_extension:
       tmpl: 'yaml'

--- a/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
+++ b/.cog/repository_templates/typescript/.github/workflows/typescript-release.tmpl
@@ -47,4 +47,4 @@ jobs:
         run: npm run build
 
       - name: Publish to NPM registry
-        run: npm publish --access public --tag {{ .Extra.GrafanaVersion }}-latest
+        run: npm publish --access public --tag {{ .Extra.TypescriptTag }}

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -74,7 +74,7 @@ function gh_run() (
 
   cd "$repo_dir"
 
-  $GH_CLI_CMD "$@"
+  $GH_CLI_CMD "$f"
 )
 
 function run_when_safe() {
@@ -142,17 +142,22 @@ git_run "${KIND_REGISTRY_PATH}" checkout main
 git_run "${KIND_REGISTRY_PATH}" pull --ff-only origin main
 
 info "Running cog"
+
 grafana_version_or_main=${GRAFANA_VERSION}
 if [ "${grafana_version_or_main}" == "next" ]; then
   grafana_version_or_main="main"
-fi
+  typescript_tag="main"
 
 # The usual "v11.6.x" branch doesn't exist for some reason
-if [ "${grafana_version_or_main}" == "v11.6.x" ]; then
+elif [ "${grafana_version_or_main}" == "v11.6.x" ]; then
   grafana_version_or_main="release-11.6.0"
+  typescript_tag="11-6-latest"
+  
+else
+  typescript_tag=$(echo "$grafana_version_or_main" | sed -e 's/^v//' -e 's/\./-/g' -e 's/x$/latest/')
 fi
 
-run_codegen "output_dir=${codegen_output_path}/%l,kind_registry_path=${KIND_REGISTRY_PATH},kind_registry_version=${GRAFANA_VERSION},grafana_version=${grafana_version_or_main},cog_version=${COG_VERSION},all_grafana_versions=${ALL_GRAFANA_VERSIONS},release_branch=${release_branch},build_timestamp=${build_timestamp}"
+run_codegen "output_dir=${codegen_output_path}/%l,kind_registry_path=${KIND_REGISTRY_PATH},kind_registry_version=${GRAFANA_VERSION},grafana_version=${grafana_version_or_main},cog_version=${COG_VERSION},all_grafana_versions=${ALL_GRAFANA_VERSIONS},release_branch=${release_branch},build_timestamp=${build_timestamp},typescript_tag=${typescript_tag}"
 
 release_branch_exists=$(git_has_branch "${foundation_sdk_path}" "${release_branch}")
 if [ "$release_branch_exists" != "0" ]; then


### PR DESCRIPTION
The tag cannot looks like a value that resembles semver. Because we have to put a different one per branch, and extra information from the configuration isn't enough to have different ones, I created `typescript_tag` (to identify that belongs to typescript process), that its setup from the script.

It changes the version from v10.1.x to 10-1-latest, and the same with the rest of the versions).