### PR TITLE
chore(backstage): update catalog info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -15,4 +15,4 @@ metadata:
 spec:
   type: library
   owner: group:default/grafana-app-platform-squad
-  lifecycle: production
+  lifecycle: experimental


### PR DESCRIPTION
Improve internal discoverability, mainly by adding a `gitops` tag to various related projects.
