### PR TITLE
Add converters config

### DIFF
--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -145,6 +145,8 @@ transformations:
 
   builders:
     - '%__config_dir%/veneers'
+  
+  converters: '%__config_dir%/converters/config.yaml'
 
 output:
   directory: '%output_dir%'

--- a/.cog/converters/config.yaml
+++ b/.cog/converters/config.yaml
@@ -1,0 +1,6 @@
+runtime:
+  - package: 'dashboard'
+    name: 'panel'
+    nameFunc: 'ConvertPanelToCode'
+    DiscriminatorField: 'type'
+    

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -74,7 +74,7 @@ function gh_run() (
 
   cd "$repo_dir"
 
-  $GH_CLI_CMD "$f"
+  $GH_CLI_CMD "$@"
 )
 
 function run_when_safe() {


### PR DESCRIPTION
Depends on https://github.com/grafana/cog/pull/856

It adds converters configuration to make `dashboard.Dashboard` to call to runtime code. Its the same that we had before the change in cog, to have everything properly work.