### PR TITLE
Go converter dataquerykind

### DIFF
--- a/.cog/templates/go/extra/cog/runtime.go
+++ b/.cog/templates/go/extra/cog/runtime.go
@@ -192,6 +192,15 @@ func ConvertDataqueryToCode(dataquery variants.Dataquery) string {
 	return NewRuntime().ConvertDataqueryToGo(dataquery)
 }
 
+func ConvertDataQueryKindToCode(dataqueryKind any, group string) string {
+	config, found := NewRuntime().dataqueryVariants[group]
+	if found && config.GoV2Converter != nil {
+		return config.GoV2Converter(dataqueryKind)
+	}
+
+	return "/* could not convert dataquerykind to go */"
+}
+
 func Dump(root any) string {
 	return dumpValue(reflect.ValueOf(root))
 }

--- a/.cog/templates/go/extra/cog/variants/variants.go
+++ b/.cog/templates/go/extra/cog/variants/variants.go
@@ -17,7 +17,8 @@ type DataqueryConfig struct {
 	Identifier                 string
 	DataqueryUnmarshaler       func(raw []byte) (Dataquery, error)
 	StrictDataqueryUnmarshaler func(raw []byte) (Dataquery, error)
-	GoConverter                func(inputPanel any) string
+	GoConverter                func(dataquery any) string
+	GoV2Converter              func(dataquery any) string
 }
 
 type Dataquery interface {

--- a/.cog/templates/go/overrides/schema_variant_dataquery.tmpl
+++ b/.cog/templates/go/overrides/schema_variant_dataquery.tmpl
@@ -54,6 +54,15 @@ func VariantConfig() variants.DataqueryConfig {
                 return {{ .Schema.EntryPoint|formatObjectName }}Converter(dataquery)
             {{- end }}
         },
+        {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
+        GoV2Converter: func(input any) string {
+            if cast, ok := input.(*dashboardv2beta1.DataQueryKind); ok {
+                return QueryConverter(*cast)
+            }
+   
+            return QueryConverter(input.(dashboardv2beta1.DataQueryKind))
+        },
+        {{- end }}
         {{- end }}
     }
 }

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -74,7 +74,7 @@ function gh_run() (
 
   cd "$repo_dir"
 
-  $GH_CLI_CMD "$f"
+  $GH_CLI_CMD "$@"
 )
 
 function run_when_safe() {


### PR DESCRIPTION
It adds code to return the proper `DataQueryKind` builder if exists. The difference from https://github.com/grafana/grafana-foundation-sdk/pull/915 is that we are using interfaces for `Dataquery` and its why we cannot reuse the old code. So I prefer to add a GoV2Converter to setup the new ones.

It depends of https://github.com/grafana/cog/pull/858, since it needs objectExists function.