### PR TITLE
fallback to per panel datasource type only if target's type was not found

### DIFF
--- a/.cog/templates/go/extra/cog/runtime.go
+++ b/.cog/templates/go/extra/cog/runtime.go
@@ -63,19 +63,6 @@ func (runtime *Runtime) UnmarshalDataqueryArray(raw []byte, dataqueryTypeHint st
 }
 
 func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string) (variants.Dataquery, error) {
-	// A hint tells us the dataquery type: let's use it.
-	if dataqueryTypeHint != "" {
-		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
-		if found {
-			dataquery, err := config.DataqueryUnmarshaler(raw)
-			if err != nil {
-				return nil, err
-			}
-
-			return dataquery.(variants.Dataquery), nil
-		}
-	}
-
 	// Dataqueries might reference the datasource to use, and its type. Let's use that.
 	partialDataquery := struct {
 		Datasource struct {
@@ -87,6 +74,19 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 	}
 	if partialDataquery.Datasource.Type != "" {
 		config, found := runtime.dataqueryVariants[partialDataquery.Datasource.Type]
+		if found {
+			dataquery, err := config.DataqueryUnmarshaler(raw)
+			if err != nil {
+				return nil, err
+			}
+
+			return dataquery.(variants.Dataquery), nil
+		}
+	}
+
+	// A hint tells us the dataquery type: let's use it.
+	if dataqueryTypeHint != "" {
+		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
 		if found {
 			dataquery, err := config.DataqueryUnmarshaler(raw)
 			if err != nil {
@@ -107,19 +107,6 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 }
 
 func (runtime *Runtime) StrictUnmarshalDataquery(raw []byte, dataqueryTypeHint string) (variants.Dataquery, error) {
-	// A hint tells us the dataquery type: let's use it.
-	if dataqueryTypeHint != "" {
-		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
-		if found {
-			dataquery, err := config.StrictDataqueryUnmarshaler(raw)
-			if err != nil {
-				return nil, err
-			}
-
-			return dataquery.(variants.Dataquery), nil
-		}
-	}
-
 	// Dataqueries might reference the datasource to use, and its type. Let's use that.
 	partialDataquery := struct {
 		Datasource struct {
@@ -131,6 +118,19 @@ func (runtime *Runtime) StrictUnmarshalDataquery(raw []byte, dataqueryTypeHint s
 	}
 	if partialDataquery.Datasource.Type != "" {
 		config, found := runtime.dataqueryVariants[partialDataquery.Datasource.Type]
+		if found {
+			dataquery, err := config.StrictDataqueryUnmarshaler(raw)
+			if err != nil {
+				return nil, err
+			}
+
+			return dataquery.(variants.Dataquery), nil
+		}
+	}
+
+	// A hint tells us the dataquery type: let's use it.
+	if dataqueryTypeHint != "" {
+		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
 		if found {
 			dataquery, err := config.StrictDataqueryUnmarshaler(raw)
 			if err != nil {

--- a/.cog/templates/python/extra/grafana_foundation_sdk/cog/runtime.py
+++ b/.cog/templates/python/extra/grafana_foundation_sdk/cog/runtime.py
@@ -36,7 +36,7 @@ class Runtime:
         self.panelcfg_variants[variant.identifier] = variant
 
     def dataquery_from_json(self, data: dict[str, Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
-        if dataquery_type_hint == "" and "datasource" in data and "type" in data["datasource"]:
+        if "datasource" in data and "type" in data["datasource"]:
             dataquery_type_hint = data["datasource"]["type"]
 
         if dataquery_type_hint != "" and dataquery_type_hint in self.dataquery_variants:


### PR DESCRIPTION
### Problem
currently during JSON unmarshal sdk assumes that dataquery type is the same for all panel targets, which is not a valid scenario for many publicly shared dashboards. in many cases panel datasource type is set to `datasource` and each target has a different ds type, which leads to absent properties like `expr` and other ones, which are specific for a certain dataquery.

### Solution
use panel global datasource type if specific target type is not set