### PR TITLE
Fix Python version in pyproject.toml

### DIFF
--- a/.cog/templates/python/extra/README.md
+++ b/.cog/templates/python/extra/README.md
@@ -9,7 +9,7 @@ A set of tools, types and *builder libraries* for building and manipulating Graf
 ## Installing
 
 ```shell
-python3 -m pip install 'grafana_foundation_sdk=={{ .Extra.BuildTimestamp }}!{{ .Extra.GrafanaVersion|registryToSemver }}'
+python3 -m pip install 'grafana_foundation_sdk=={{ if eq .Extra.GrafanaVersion "next" }}{{ .Extra.BuildTimestamp }}{{ else }}{{ .Extra.BuildTimestamp }}!{{ .Extra.GrafanaVersion|registryToSemver }}{{ end }}'
 ```
 
 ## Example usage

--- a/.cog/templates/python/extra/pyproject.toml
+++ b/.cog/templates/python/extra/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "traces",
     "metrics"
 ]
-version = "{{ .Extra.BuildTimestamp }}!{{ .Extra.GrafanaVersion|registryToSemver }}"
+version = "{{ if eq .Extra.GrafanaVersion "next" }}{{ .Extra.BuildTimestamp }}{{ else }}{{ .Extra.BuildTimestamp }}!{{ .Extra.GrafanaVersion|registryToSemver }}{{ end }}"
 dependencies = []
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
The pyproject.toml was not complying with PEP 508 because using "next" as the Grafana version is not PEP 440 compliant (version epochs have to be `E!X.Y`, see [PEP 440 Version Epochs]).

This breaks `uv`:

```
❯ uv lock
  × Failed to download and build `grafana-foundation-sdk @ git+https://github.com/grafana/grafana-foundation-sdk.git@next+cog-v0.0.x#subdirectory=python`
  ├─▶ Failed to parse metadata from built wheel
  ╰─▶ TOML parse error at line 16, column 11
         |
      16 | version = "1758039686!next"
         |           ^^^^^^^^^^^^^^^^^
      expected version to have a non-empty release component after an epoch, but no ASCII digits after the epoch were found
```

[PEP 440 Version Epochs]: https://peps.python.org/pep-0440/#version-epochs