### PR TITLE
Prepare template overrides to proper unmarshal composables for dashboard v2

### DIFF
--- a/.cog/templates/go/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl
@@ -33,7 +33,7 @@ func (resource *{{ .Object.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) err
 	{{- $fmt := importStdPkg "fmt" -}}
 	{{- $cog := importPkg "cog" }}
 	if fields["spec"] != nil {
-		dataquery, err := cog.UnmarshalDataquery(fields["spec"], resource.Kind)
+		dataquery, err := cog.UnmarshalDataquery(fields["spec"], resource.Group)
 		if err != nil {
 			return fmt.Errorf("error decoding field 'spec': %w", err)
 		}

--- a/.cog/templates/go/overrides/object_dashboardv2beta1_DataQueryKind_field_spec_custom_strict_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2beta1_DataQueryKind_field_spec_custom_strict_unmarshal.tmpl
@@ -1,6 +1,6 @@
 {{- define "object_dashboardv2beta1_DataQueryKind_field_spec_custom_strict_unmarshal" -}}
 	{{- $cog := importPkg "cog" -}}
-	dataquery, err := cog.UnmarshalDataquery(fields["spec"], resource.Kind)
+	dataquery, err := cog.UnmarshalDataquery(fields["spec"], resource.Group)
 	if err != nil {
 		errs = append(errs, cog.MakeBuildErrors("spec", err)...)
 	} else {

--- a/.cog/templates/go/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
@@ -60,7 +60,7 @@ func (resource *{{ .Object.Name|formatObjectName }}) UnmarshalJSON(raw []byte) e
 		return fmt.Errorf("error decoding field 'fieldConfig': %w", err)
 	}
 
-	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Kind)
+	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
 	if found && variantCfg.FieldConfigUnmarshaler != nil {
 		fakeFieldConfigSource := struct {
 			Defaults struct {
@@ -85,7 +85,7 @@ func (resource *{{ .Object.Name|formatObjectName }}) UnmarshalJSON(raw []byte) e
 {{- define "object_dashboardv2beta1_VizConfigKind_spec_options" -}}
 	{{- $json := importStdPkg "encoding/json" -}}
 	{{- $cog := importPkg "cog" -}}
-	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Kind)
+	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
 	if found && variantCfg.OptionsUnmarshaler != nil {
 		options, err := variantCfg.OptionsUnmarshaler(specFields["options"])
 		if err != nil {

--- a/.cog/templates/go/overrides/object_dashboardv2beta1_VizConfigKind_field_spec_custom_strict_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2beta1_VizConfigKind_field_spec_custom_strict_unmarshal.tmpl
@@ -33,7 +33,7 @@
 	if err := json.Unmarshal(specFields["fieldConfig"], &spec.FieldConfig); err != nil {
 		errs = append(errs, cog.MakeBuildErrors("spec.fieldConfig", err)...)
 	} else {
-		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Kind)
+		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
 		if found && variantCfg.StrictFieldConfigUnmarshaler != nil {
 			fakeFieldConfigSource := struct {
 				Defaults struct {
@@ -57,7 +57,7 @@
 {{- define "object_dashboardv2beta1_VizConfigKind_spec_options_strict_unmarshal" -}}
 	{{- $json := importStdPkg "encoding/json" -}}
 	{{- $cog := importPkg "cog" -}}
-	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Kind)
+	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
 	if found && variantCfg.StrictOptionsUnmarshaler != nil {
 		options, err := variantCfg.StrictOptionsUnmarshaler(specFields["options"])
 		if err != nil {

--- a/.cog/templates/java/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl
+++ b/.cog/templates/java/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl
@@ -33,8 +33,8 @@ public class {{ .Object.Name | upperCamelCase }}Deserializer extends JsonDeseria
         }
         {{- end }}
         {{- end }}
-        if ({{ .Object.Name | lowerCamelCase }}.kind != null && !{{ .Object.Name | lowerCamelCase }}.kind.trim().isEmpty()) {
-            Class<? extends Dataquery> clazz = Registry.getDataquery({{ .Object.Name | lowerCamelCase }}.kind);
+        if ({{ .Object.Name | lowerCamelCase }}.group != null && !{{ .Object.Name | lowerCamelCase }}.group.trim().isEmpty()) {
+            Class<? extends Dataquery> clazz = Registry.getDataquery({{ .Object.Name | lowerCamelCase }}.group);
             if (clazz != null) {
                 {{ $.Object.Name | lowerCamelCase }}.spec = mapper.treeToValue(root.get("spec"), clazz);
             } else {

--- a/.cog/templates/java/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/java/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
@@ -43,9 +43,9 @@ public class {{ .Object.Name | upperCamelCase }}Deserializer extends JsonDeseria
         {{ .Field.Type | formatType }} {{ .Field.Name }} = new {{ .Field.Type | formatType }}();
         JsonNode specNode = root.get("{{ .Field.Name }}");
         if (specNode != null && !specNode.isNull()) {
-            PanelConfig panelConfig = Registry.getPanel({{ .ObjectName }}.kind);
+            PanelConfig panelConfig = Registry.getPanel({{ .ObjectName }}.group);
             if (panelConfig == null) {
-                throw new IllegalArgumentException("Unknown panel type: " + {{ .ObjectName }}.kind);
+                throw new IllegalArgumentException("Unknown panel type: " + {{ .ObjectName }}.group);
             }
             {{- range $i, $field := (.Field.Type|resolveRefs).AsStruct.Fields }}
             {{ if gt $i 0 }}else {{ end }}if (specNode.has("{{ $field.Name }}")) {

--- a/.cog/templates/php/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl.tmpl
+++ b/.cog/templates/php/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl.tmpl
@@ -24,6 +24,6 @@ public static function fromArray(array $inputData): self
 isset($data['spec']) ? (function($input) {
     /** @var array<string, mixed> $spec */
     $spec = $input['spec'];
-    return \Grafana\Foundation\Cog\Runtime::get()->dataqueryFromArray($spec, $input['kind'] ?? '');
+    return \Grafana\Foundation\Cog\Runtime::get()->dataqueryFromArray($spec, $input['group'] ?? '');
 })($data) : null
 {{- end }}

--- a/.cog/templates/php/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/php/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
@@ -70,7 +70,7 @@ isset($spec["fieldConfig"]) ? (function(string $panelType, $panel) {
     $fieldConfigSource->defaults->custom = ($config->fieldConfigFromArray)($defaults["custom"]);
 
     return $fieldConfigSource;
-})($kind, $spec) : null
+})($group, $spec) : null
 {{- end }}
 
 {{- define "object_dashboardv2beta1_VizConfigKind_spec_options_unmarshal" -}}
@@ -88,5 +88,5 @@ isset($spec["options"]) ? (function(string $panelType, $panel) {
     }
 
     return ($config->optionsFromArray)($options);
-})($kind, $spec) : null
+})($group, $spec) : null
 {{- end }}

--- a/.cog/templates/python/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl.tmpl
+++ b/.cog/templates/python/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl.tmpl
@@ -18,5 +18,5 @@ def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
 
 {{- define "dashboardv2beta1_DataQueryKind_spec_unmarshal" -}}
 {{- $cogruntime := importModule "cogruntime" "..cog" "runtime" -}}
-{{ $cogruntime }}.dataquery_from_json(data["{{ .Field.Name }}"],  data["kind"])
+{{ $cogruntime }}.dataquery_from_json(data["{{ .Field.Name }}"],  data["group"])
 {{- end }}

--- a/.cog/templates/python/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/python/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
@@ -42,7 +42,7 @@ VizConfigSpec(
 
 {{- define "object_dashboardv2beta1_VizConfigKind_spec_fieldConfig_unmarshal" -}}
 {{- $cogruntime := importModule "cogruntime" "..cog" "runtime" -}}
-FieldConfigSource.from_json({**data["spec"]["fieldConfig"], **{"defaults": {**defaults, **{"custom": {{ $cogruntime }}.panelcfg_field_config_from_json(custom, data["kind"])}}}})
+FieldConfigSource.from_json({**data["spec"]["fieldConfig"], **{"defaults": {**defaults, **{"custom": {{ $cogruntime }}.panelcfg_field_config_from_json(custom, data["group"])}}}})
 {{- end }}
 
 {{- define "object_dashboardv2beta1_VizConfigKind_spec_options_unmarshal" -}}


### PR DESCRIPTION
It adds override templates for `DataQueryKind` and `VizConfigKind` to use them instead the one that cog generates by default, when we unmarshal a JSON. The templates are copied and updated from [the sandbox branch](https://github.com/grafana/cog/pull/722) that we are using to support legacy + v2 schemas.

For example, `VizConfigKind` needs to know how to setup the options and field config from the panels to the proper fields.

We don't have them for Typescript because its default unmarshal works properly without any other check.