### PR TITLE
PHP: Fix invalid empty values when we find concrete scalars or constant references

### DIFF
--- a/.cog/templates/php/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl.tmpl
+++ b/.cog/templates/php/overrides/object_dashboardv2beta1_DataQueryKind_custom_unmarshal.tmpl.tmpl
@@ -7,13 +7,13 @@ public static function fromArray(array $inputData): self
     /** @var {{ typeShape .Object.Type }} $inputData */
     $data = $inputData;
     return new self(
-        {{- range $field := .Object.Type.Struct.Fields }}
-        {{ $field.Name }}: {{ if eq $field.Name "spec" -}}
-        {{ template "dashboardv2beta1_DataQueryKind_spec_unmarshal" }}
-        {{- else if $field.Type.IsConcreteScalar }}
-        {{ continue}}
+        {{- range $field := .Object.Type.Struct.Fields }} 
+        {{ if eq $field.Name "spec" -}}
+        {{ $field.Name }}: {{ template "dashboardv2beta1_DataQueryKind_spec_unmarshal" }}
+        {{- else if or $field.Type.IsConcreteScalar $field.Type.IsConstantRef }}
+        {{ continue }}
         {{- else -}}
-        {{ unmarshalForType $field.Type (print "$data[\"" $field.Name "\"]") }}
+        {{ $field.Name }}: {{ unmarshalForType $field.Type (print "$data[\"" $field.Name "\"]") }}
         {{- end -}},
         {{- end }}
    );

--- a/.cog/templates/php/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/php/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
@@ -8,12 +8,12 @@ public static function fromArray(array $inputData): self
     $data = $inputData;
     return new self(
         {{- range $field := .Object.Type.Struct.Fields }}
-        {{ $field.Name }}: {{ if eq $field.Name "spec" -}}
-        {{ template "object_dashboardv2beta1_VizConfigKind_spec_unmarshal" (dict "Field" $field) }}
-        {{- else if $field.Type.IsConcreteScalar }}
-        {{ continue}}
+        {{- if eq $field.Name "spec" -}}
+        {{ $field.Name }}: {{ template "object_dashboardv2beta1_VizConfigKind_spec_unmarshal" (dict "Field" $field) }}
+        {{- else if or $field.Type.IsConcreteScalar $field.Type.IsConstantRef }}
+        {{ continue }}
         {{- else -}}
-        {{ unmarshalForType $field.Type (print "$data[\"" $field.Name "\"]") }}
+        {{ $field.Name }}: {{ unmarshalForType $field.Type (print "$data[\"" $field.Name "\"]") }}
         {{- end -}},
         {{- end }}
    );


### PR DESCRIPTION
We were generating empty values when we detect a constant reference or a concrete scalar, making invalid output. Its because the field was always set, but not its value.