### PR TITLE
PHP: Add missing configuration to make converters to work

### DIFF
--- a/.cog/templates/php/extra/src/Cog/DataqueryConfig.php
+++ b/.cog/templates/php/extra/src/Cog/DataqueryConfig.php
@@ -15,15 +15,22 @@ final class DataqueryConfig
      * @var (callable(Dataquery): string)|null
      */
     public $convert;
+    
+    /**
+     * @var (callable(\Grafana\Foundation\Dashboardv2beta1\DataQueryKind): string)|null
+     */
+    public $convertv2;
 
     /**
      * @param callable(array<string, mixed>): Dataquery $fromArray
      * @param (callable(Dataquery): string)|null $convert
+     * @param (callable(\Grafana\Foundation\Dashboardv2beta1\DataQueryKind): string)|null $convertv2
      */
-    public function __construct(string $identifier, callable $fromArray, ?callable $convert = null)
+    public function __construct(string $identifier, callable $fromArray, ?callable $convert = null, ?callable $convertv2 = null)
     {
         $this->identifier = $identifier;
         $this->fromArray = $fromArray;
         $this->convert = $convert;
+        $this->convertv2 = $convertv2;
     }
 }

--- a/.cog/templates/php/extra/src/Cog/PanelcfgConfig.php
+++ b/.cog/templates/php/extra/src/Cog/PanelcfgConfig.php
@@ -7,7 +7,7 @@ final class PanelcfgConfig
     public readonly string $identifier;
 
     /**
-     * @var (callable(\Grafana\Foundation\Dashboard\Panel): string)|null
+     * @var (callable(mixed): string)|null
      */
     public $convert;
 
@@ -22,7 +22,7 @@ final class PanelcfgConfig
     public $fieldConfigFromArray;
 
     /**
-     * @param (callable(\Grafana\Foundation\Dashboard\Panel): string)|null $convert
+     * @param (callable(mixed): string)|null $convert
      * @param (callable(array<string, mixed>): object)|null $optionsFromArray
      * @param (callable(array<string, mixed>): object)|null $fieldConfigFromArray
      */

--- a/.cog/templates/php/extra/src/Cog/Runtime.php
+++ b/.cog/templates/php/extra/src/Cog/Runtime.php
@@ -96,7 +96,7 @@ final class Runtime
         return $queries;
     }
 
-    public function convertPanelToCode(\Grafana\Foundation\Dashboard\Panel $panel, string $panelType): string
+    public function convertPanelToCode(mixed $panel, string $panelType): string
     {
         if (!$this->panelcfgVariantExists($panelType)) {
             return '/* could not convert panel to PHP */';
@@ -125,6 +125,20 @@ final class Runtime
             return '/* could not convert dataquery to PHP */';
         }
 
+        return $convert($dataquery);
+    }
+
+    public function convertDataQueryKindToCode(\Grafana\Foundation\Dashboardv2beta1\DataQueryKind $dataquery, string $group): string 
+    {
+    	if (!isset($this->dataqueryVariants[$group])) {
+            return '/* could not convert DataQueryKind to PHP */';
+        }
+    
+        $convert = $this->dataqueryVariants[$group]->convertv2;
+        if ($convert === null) {
+            return '/* could not convert DataQueryKind to PHP */';
+        }
+        
         return $convert($dataquery);
     }
 }

--- a/.cog/templates/php/overrides/dynamic_files.tmpl
+++ b/.cog/templates/php/overrides/dynamic_files.tmpl
@@ -16,6 +16,7 @@
 
 {{ define "schema_dataquery_variantConfig_file" -}}
 {{- $convert := "null" -}}
+{{- $convertv2 := "null" -}}
 {{- $fromArray := "null" -}}
 {{- $entryPointNotFound := not (schemaHasObject .Schema .Schema.EntryPoint) -}}
 
@@ -30,6 +31,11 @@
     {{- if .Schema.EntryPointType|resolvesToDisjunction -}}
     {{- $convert = convertDisjunctionFunc .Schema.EntryPointType -}}
     {{- end -}}
+    
+    {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
+    {{- $convertv2 = print "[QueryConverter::class, 'convert']" -}}
+    {{- end }}
+    
 {{- end -}}
 <?php
 
@@ -43,8 +49,12 @@ final class VariantConfig
             identifier: '{{ .Schema.Metadata.Identifier }}',
             fromArray: {{ $fromArray }},
             convert: {{ $convert }},
+            {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
+            convertv2: {{ $convertv2 }},
+            {{- end }}
         );
     }
+
 }
 {{ end }}
 
@@ -62,7 +72,12 @@ final class VariantConfig
 {{- end -}}
 
 {{- if .Config.Converters -}}
+{{- if objectExists "dashboardv2beta1" "VizConfigKind" }}
+{{- $dashboardv2beta1 := fullNamespaceRef "dashboardv2beta1" }}
+{{- $convert = "[self::class, 'convert']" -}}
+{{- else }}
 {{- $convert = "[PanelConverter::class, 'convert']" -}}
+{{- end }}
 {{- end -}}
 <?php
 
@@ -79,5 +94,20 @@ final class VariantConfig
             convert: {{ $convert }},
         );
     }
+    
+    {{- if objectExists "dashboardv2beta1" "VizConfigKind" }}
+    private static function convert(mixed $input): string
+        {
+            if ($input instanceof {{ fullNamespaceRef "Dashboard\\Panel" }}) {
+                return PanelConverter::convert($input);
+            }
+    
+            if ($input instanceof {{ fullNamespaceRef "Dashboardv2beta1\\VizConfigKind" }}) {
+                return VisualizationConverter::convert($input);
+            }
+    
+            return '/* could not convert panel */';
+        }
+    {{- end }}
 }
 {{ end }}

--- a/.cog/templates/php/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/php/overrides/object_dashboardv2beta1_VizConfigKind_custom_unmarshal.tmpl
@@ -24,8 +24,8 @@ public static function fromArray(array $inputData): self
 isset($data['spec']) ? (function($input) {
     /** @var {{ typeShape (.Field.Type|resolveRefs) }} $spec */
     $spec = $input['spec'];
-    /** @var string $kind */
-    $kind = $input['kind'] ?? '';
+    /** @var string $group */
+    $group = $input['group'] ?? '';
     return new VizConfigSpec(
         {{- range $field := (.Field.Type|resolveRefs).Struct.Fields }}
         {{ $field.Name }}: {{ if eq $field.Name "options" -}}


### PR DESCRIPTION
It depends on https://github.com/grafana/cog/pull/880.

It adds missing configuration for PHP converters and it also fixes compiler errors.