### PR TITLE
Fix plugin identifiers for Go and Java

### DIFF
--- a/.cog/templates/go/overrides/schema_variant_dataquery.tmpl
+++ b/.cog/templates/go/overrides/schema_variant_dataquery.tmpl
@@ -14,7 +14,7 @@
 // This configuration describes how to unmarshal it, convert it to code, …
 func VariantConfig() variants.DataqueryConfig {
     return variants.DataqueryConfig{
-        Identifier: "{{ .Schema.Metadata.Identifier|lower }}",
+        Identifier: "{{ .Schema.Metadata.Identifier }}",
         DataqueryUnmarshaler: func (raw []byte) (variants.Dataquery, error) {
             dataquery := &{{ .Schema.EntryPoint|formatObjectName }}{}
 

--- a/.cog/templates/go/overrides/schema_variant_panelcfg.tmpl
+++ b/.cog/templates/go/overrides/schema_variant_panelcfg.tmpl
@@ -13,7 +13,7 @@
 // This configuration describes how to unmarshal it, convert it to code, …
 func VariantConfig() {{ $variants }}.PanelcfgConfig {
 	return {{ $variants }}.PanelcfgConfig{
-		Identifier: "{{ .Schema.Metadata.Identifier|lower }}",
+		Identifier: "{{ .Schema.Metadata.Identifier }}",
 		{{- if .Schema.HasObject "Options" }}
 		{{- $json := importStdPkg "encoding/json" -}}
 		OptionsUnmarshaler: func (raw []byte) (any, error) {

--- a/.cog/templates/java/extra/src/main/java/com/grafana/foundation/cog/variants/Registry.java
+++ b/.cog/templates/java/extra/src/main/java/com/grafana/foundation/cog/variants/Registry.java
@@ -16,11 +16,11 @@ public class Registry {
     
     static {
         {{- range $schema := $panelSchemas }}
-        registerPanel("{{ $schema.Metadata.Identifier|lower }}", com.grafana.foundation.{{ $schema.Package }}.Options.class, {{ if $schema.HasObject "FieldConfig" }}com.grafana.foundation.{{ $schema.Package }}.FieldConfig.class{{ else }}null{{ end }}{{ if $.Data.Config.GenerateConverters }}, new com.grafana.foundation.{{ $schema.Package }}.PanelConverter.class{{ end }});
+        registerPanel("{{ $schema.Metadata.Identifier }}", com.grafana.foundation.{{ $schema.Package }}.Options.class, {{ if $schema.HasObject "FieldConfig" }}com.grafana.foundation.{{ $schema.Package }}.FieldConfig.class{{ else }}null{{ end }}{{ if $.Data.Config.GenerateConverters }}, new com.grafana.foundation.{{ $schema.Package }}.PanelConverter.class{{ end }});
         {{- end }}
 
         {{- range $schema := $dataquerySchemas }}
-        registerDataquery("{{ $schema.Metadata.Identifier|lower }}", com.grafana.foundation.{{ $schema.Package }}.{{ $schema.EntryPoint|formatObjectName }}.class{{ if $.Data.Config.GenerateConverters }}, new com.grafana.foundation.{{ $schema.Package }}.{{ $schema.EntryPoint|formatObjectName }}MapperConverter.class{{ end }});
+        registerDataquery("{{ $schema.Metadata.Identifier }}", com.grafana.foundation.{{ $schema.Package }}.{{ $schema.EntryPoint|formatObjectName }}.class{{ if $.Data.Config.GenerateConverters }}, new com.grafana.foundation.{{ $schema.Package }}.{{ $schema.EntryPoint|formatObjectName }}MapperConverter.class{{ end }});
         {{- end }}
     }
 


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana-foundation-sdk/issues/953

Go and Java were applying "lower" function to the identifiers making them invalid.