### PR TITLE
Add dashboard v2 stable resource

### DIFF
--- a/.cog/converters/config.yaml
+++ b/.cog/converters/config.yaml
@@ -1,15 +1,25 @@
 runtime:
-  - package: 'dashboard'
-    name: 'panel'
-    name_func: 'ConvertPanelToCode'
-    discriminator_field: 'type'
+  - package: "dashboard"
+    name: "panel"
+    name_func: "ConvertPanelToCode"
+    discriminator_field: "type"
 
-  - package: 'dashboardv2beta1'
-    name: 'vizconfigkind'
-    name_func: 'ConvertPanelToCode'
-    discriminator_field: 'group'
+  - package: "dashboardv2beta1"
+    name: "vizconfigkind"
+    name_func: "ConvertPanelToCode"
+    discriminator_field: "group"
 
-  - package: 'dashboardv2beta1'
-    name: 'dataquerykind'
-    name_func: 'ConvertDataQueryKindToCode'
-    discriminator_field: 'group'
+  - package: "dashboardv2beta1"
+    name: "dataquerykind"
+    name_func: "ConvertDataQueryKindToCode"
+    discriminator_field: "group"
+
+  - package: "dashboardv2"
+    name: "vizconfigkind"
+    name_func: "ConvertPanelToCode"
+    discriminator_field: "group"
+
+  - package: "dashboardv2"
+    name: "dataquerykind"
+    name_func: "ConvertDataQueryKindToCode"
+    discriminator_field: "group"

--- a/.cog/resources/dashboardv2/builder-transforms/common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/common.yaml
@@ -1,0 +1,404 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [all]
+
+package: dashboardv2
+
+builders:
+  # overrides and transformations related
+  - omit: { by_object: MatcherConfig }
+  - omit: { by_object: DynamicConfigValue }
+  - omit: { by_object: Threshold }
+
+  - omit: { by_object: ValueMap }
+  - omit: { by_object: RangeMap }
+  - omit: { by_object: RegexMap }
+  - omit: { by_object: SpecialValueMap }
+
+  - omit: { by_object: CustomVariableValue }
+  - omit: { by_object: Kind }
+
+  ###################
+  # AnnotationQuery #
+  ###################
+
+  - merge_into:
+      source: AnnotationQuerySpec
+      destination: AnnotationQueryKind
+      under_path: spec
+  - rename:
+      by_object: AnnotationQueryKind
+      as: AnnotationQuery
+
+  - omit: { by_object: AnnotationQuerySpec }
+
+  ####################
+  # LibraryPanelKind #
+  ####################
+
+  - merge_into:
+      source: LibraryPanelKindSpec
+      destination: LibraryPanelKind
+      under_path: spec
+  - rename:
+      by_object: LibraryPanelKind
+      as: LibraryPanel
+
+  - omit: { by_object: LibraryPanelKindSpec }
+
+  # No need for builders for structs generated from a disjunction
+  - omit: { generated_from_disjunction: true }
+
+  ###########
+  # Layouts #
+  ###########
+
+  ##################
+  # AutoGridLayout #
+  ##################
+
+  - merge_into:
+      source: AutoGridLayoutSpec
+      destination: AutoGridLayoutKind
+      under_path: spec
+  - rename:
+      by_object: AutoGridLayoutKind
+      as: AutoGrid
+  - omit: { by_object: AutoGridLayoutSpec }
+
+  - merge_into:
+      source: AutoGridLayoutItemSpec
+      destination: AutoGridLayoutItemKind
+      under_path: spec
+  - rename:
+      by_object: AutoGridLayoutItemKind
+      as: AutoGridItem
+  - omit: { by_object: AutoGridLayoutItemSpec }
+
+  - merge_into:
+      source: ElementReference
+      destination: AutoGridItem
+      under_path: spec.element
+
+  - add_option:
+      by_name: AutoGrid
+      option:
+        name: withItem
+        arguments:
+          - name: name
+            type: &type_string
+              kind: scalar
+              scalar: {scalar_kind: string}
+        assignments:
+          - method: append
+            path: spec.items
+            value:
+              envelope:
+                values:
+                  - field: kind
+                    value: { constant: AutoGridLayoutItem }
+                  - field: spec
+                    value:
+                      envelope:
+                        values:
+                          - field: element
+                            value:
+                              envelope:
+                                values:
+                                  - field: kind
+                                    value: { constant: ElementReference }
+                                  - field: name
+                                    value:
+                                      argument: { name: name, type: *type_string }
+
+  ##############
+  # RowsLayout #
+  ##############
+
+  - merge_into:
+      source: RowsLayoutSpec
+      destination: RowsLayoutKind
+      under_path: spec
+  - rename:
+      by_object: RowsLayoutKind
+      as: Rows
+  - omit: { by_object: RowsLayoutSpec }
+
+  - merge_into:
+      source: RowsLayoutRowSpec
+      destination: RowsLayoutRowKind
+      under_path: spec
+  - rename:
+      by_object: RowsLayoutRowKind
+      as: Row
+  - omit: { by_object: RowsLayoutRowSpec }
+
+  ##############
+  # TabsLayout #
+  ##############
+
+  - merge_into:
+      source: TabsLayoutSpec
+      destination: TabsLayoutKind
+      under_path: spec
+  - rename:
+      by_object: TabsLayoutKind
+      as: Tabs
+  - omit: { by_object: TabsLayoutSpec }
+
+  - merge_into:
+      source: TabsLayoutTabSpec
+      destination: TabsLayoutTabKind
+      under_path: spec
+  - rename:
+      by_object: TabsLayoutTabKind
+      as: Tab
+  - omit: { by_object: TabsLayoutTabSpec }
+
+  ##############
+  # GridLayout #
+  ##############
+
+  - merge_into:
+      source: GridLayoutSpec
+      destination: GridLayoutKind
+      under_path: spec
+  - rename:
+      by_object: GridLayoutKind
+      as: Grid
+  - omit: { by_object: GridLayoutSpec }
+
+  - merge_into:
+      source: GridLayoutItemSpec
+      destination: GridLayoutItemKind
+      under_path: spec
+  - rename:
+      by_object: GridLayoutItemKind
+      as: GridItem
+  - omit: { by_object: GridLayoutItemSpec }
+
+  - merge_into:
+      source: ElementReference
+      destination: GridItem
+      under_path: spec.element
+
+  ###########
+  # Queries #
+  ###########
+
+  - merge_into:
+      source: QueryGroupSpec
+      destination: QueryGroupKind
+      under_path: spec
+  - omit: { by_object: QueryGroupSpec }
+  - rename:
+      by_object: QueryGroupKind
+      as: QueryGroup
+
+  - merge_into:
+      source: PanelQuerySpec
+      destination: PanelQueryKind
+      under_path: spec
+  - omit: { by_object: PanelQuerySpec }
+  - rename:
+      by_object: PanelQueryKind
+      as: Target
+
+  - properties:
+      by_name: QueryGroup
+      set:
+        - name: nextQueryId
+          type:
+            kind: scalar
+            scalar: {scalar_kind: uint32}
+
+  ###################
+  # Transformations #
+  ###################
+
+  - merge_into:
+      source: TransformationSpec
+      destination: TransformationKind
+      under_path: spec
+  - omit: { by_object: TransformationSpec }
+  - rename:
+      by_object: TransformationKind
+      as: Transformation
+
+  ##############
+  # Dashboards #
+  ##############
+
+  - rename:
+      by_object: TimeSettingsSpec
+      as: TimeSettings
+
+  - promote_options_to_constructor:
+      by_name: DashboardSpec
+      options: [title]
+
+  # Rearrange panel-related builders
+  - merge_into:
+      source: PanelSpec
+      destination: PanelKind
+      under_path: spec
+  - omit: { by_object: PanelSpec }
+  - rename:
+      by_object: PanelKind
+      as: Panel
+
+  - merge_into:
+      source: FieldConfig
+      destination: VizConfigSpec
+      under_path: fieldConfig.defaults
+      rename_options:
+        color: colorScheme
+        links: dataLinks
+  - merge_into:
+      source: FieldConfigSource
+      destination: VizConfigSpec
+      under_path: fieldConfig
+  - merge_into:
+      source: VizConfigSpec
+      destination: VizConfigKind
+      under_path: spec
+
+  - omit: { by_object: FieldConfig }
+  - omit: { by_object: FieldConfigSource }
+  - omit: { by_object: VizConfigSpec }
+
+options:
+  - omit: { by_builder: LibraryPanel.spec }
+  - omit: { by_builder: AnnotationQuery.spec }
+
+  ##############
+  # RowsLayout #
+  ##############
+
+  - omit: { by_builder: Rows.spec }
+  - omit: { by_builder: Row.spec }
+
+  # Append a single `row` value instead of a map of everything
+  - duplicate:
+      by_builder: Rows.rows
+      as: row
+  - array_to_append:
+      by_builder: Rows.row
+
+  ##################
+  # AutoGridLayout #
+  ##################
+
+  - omit: { by_builder: AutoGrid.spec }
+  - omit: { by_builder: AutoGridItem.spec }
+
+  # Append a single `item` value instead of a map of everything
+  - duplicate:
+      by_builder: AutoGrid.items
+      as: item
+  - array_to_append:
+      by_builder: AutoGrid.item
+
+  - omit: { by_builder: AutoGridItem.element }
+
+  ##############
+  # TabsLayout #
+  ##############
+
+  - omit: { by_builder: Tabs.spec }
+  - omit: { by_builder: Tab.spec }
+
+  # Append a single `tab` value instead of a list of everything
+  - duplicate:
+      by_builder: Tabs.tabs
+      as: tab
+  - array_to_append:
+      by_builder: Tabs.tab
+
+  ##############
+  # GridLayout #
+  ##############
+
+  # spec options are leftovers from the merge_into veneer
+  - omit: { by_builder: Grid.spec }
+  - omit: { by_builder: GridItem.spec }
+
+  # Append a single `item` value instead of a list of everything
+  - duplicate:
+      by_builder: Grid.items
+      as: item
+  - array_to_append:
+      by_builder: Grid.item
+
+  - omit: { by_builder: GridItem.element }
+
+  ###########
+  # Queries #
+  ###########
+
+  # spec options are leftovers from the merge_into veneer
+  - omit: { by_builder: QueryGroup.spec }
+  - omit: { by_name: PanelQueryKind.spec }
+
+  # queries() -> targets()
+  - rename:
+      by_name: QueryGroupKind.queries
+      as: targets
+
+  # Append a single target instead forcing to define all of them at once
+  - duplicate:
+      by_name: QueryGroupKind.targets
+      as: target
+  - array_to_append:
+      by_name: QueryGroupKind.target
+
+  # Append a single transformation instead forcing to define all of them at once
+  - duplicate:
+      by_name: QueryGroupKind.transformations
+      as: transformation
+  - array_to_append:
+      by_name: QueryGroupKind.transformation
+
+  ###################
+  # Transformations #
+  ###################
+
+  # spec options are leftovers from the merge_into veneer
+  - omit: { by_builder: Transformation.spec }
+
+  ##########
+  # Panels #
+  ##########
+
+  # spec options are leftovers from the merge_into veneer
+  - omit: { by_name: PanelKind.spec }
+
+  # VizConfig() -> Visualization()
+  - rename:
+      by_name: PanelKind.VizConfig
+      as: visualization
+
+  ##############
+  # Dashboards #
+  ##############
+
+  # Append a single `element` value instead of a map of everything
+  - duplicate:
+      by_builder: DashboardSpec.Elements
+      as: element
+  - map_to_index:
+      by_builder: DashboardSpec.element
+
+  # Append a single override instead forcing to define all of them at once
+  - duplicate:
+      by_name: VizConfigKind.overrides
+      as: override
+  - array_to_append:
+      by_name: VizConfigKind.override
+
+  # Append a single variable instead forcing to define all of them at once
+  - duplicate:
+      by_builder: DashboardSpec.variables
+      as: variable
+  - array_to_append:
+      by_builder: DashboardSpec.variable

--- a/.cog/resources/dashboardv2/builder-transforms/common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/common.yaml
@@ -46,9 +46,6 @@ builders:
 
   - omit: { by_object: LibraryPanelKindSpec }
 
-  # No need for builders for structs generated from a disjunction
-  - omit: { generated_from_disjunction: true }
-
   ###########
   # Layouts #
   ###########
@@ -204,20 +201,12 @@ builders:
   - rename:
       by_object: PanelQueryKind
       as: Target
-
-  - properties:
-      by_name: QueryGroup
-      set:
-        - name: nextQueryId
-          type:
-            kind: scalar
-            scalar: { scalar_kind: uint32 }
-
+      
   # Dataquery DataQueryKind composability
   - compose:
       by_variant: dataquery
       source_builder_name: dashboardv2.DataQueryKind
-      composed_builder_name: Query
+      composed_builder_name: QueryV2
       plugin_discriminator_field: group
       composition_map: # Builder → assignment root path
         __schema_entrypoint: spec
@@ -227,6 +216,14 @@ builders:
         datasource: old_datasource
 
   - omit: { by_name: DataQueryKind }
+
+  - properties:
+      by_name: QueryGroup
+      set:
+        - name: nextQueryId
+          type:
+            kind: scalar
+            scalar: { scalar_kind: uint32 }
 
   ###################
   # Transformations #
@@ -250,7 +247,7 @@ builders:
       as: TimeSettings
 
   - promote_options_to_constructor:
-      by_name: DashboardSpec
+      by_name: Dashboard
       options: [title]
 
   # Rearrange panel-related builders
@@ -278,34 +275,34 @@ builders:
       source: VizConfigSpec
       destination: VizConfigKind
       under_path: spec
-
+      
   # Panels VizConfigSpec composability
   - compose:
       by_variant: panelcfg
-      # this should run after the "dashboard" package has done its thing
+      # this should run after the "dashboard" package has done its thing, 
       # so these builders aren't needed anymore once the composition is done.
-      preserve_original_builders: false
       source_builder_name: dashboardv2.VizConfigKind
-      composed_builder_name: Visualization
+      composed_builder_name: VisualizationV2
       plugin_discriminator_field: group
+      # Dashboardv2 is generated before dashboardv2beta1, so we need to preserve the original builders
+      preserve_original_builders: true
       composition_map: # Builder → assignment root path
         Options: "spec.options"
         FieldConfig: "spec.fieldConfig.defaults.custom"
       exclude_options: [
-          "spec", # merged with another builder
-          "defaults", # merged with another builder
-          "fieldConfig", # merged with another builder
-          "options", # comes from a panel plugin
-          "custom", # comes from a panel plugin
-          "version", # TODO: check if it's relevant or not
-          "filterable", # TODO: check if it's relevant or not
-          "writeable", # TODO: check if it's relevant or not
-        ]
+        "spec", # merged with another builder
+        "defaults", # merged with another builder
+        "fieldConfig", # merged with another builder
+        "options", # comes from a panel plugin
+        "custom", # comes from a panel plugin
+        "version", # TODO: check if it's relevant or not
+        "filterable", # TODO: check if it's relevant or not
+        "writeable", # TODO: check if it's relevant or not
+      ]
 
   - omit: { by_object: FieldConfig }
   - omit: { by_object: FieldConfigSource }
   - omit: { by_object: VizConfigSpec }
-  - omit: { by_name: VizConfigKind }
 
 options:
   - omit: { by_builder: LibraryPanel.spec }
@@ -424,21 +421,21 @@ options:
 
   # Append a single `element` value instead of a map of everything
   - duplicate:
-      by_builder: DashboardSpec.Elements
+      by_builder: Dashboard.Elements
       as: element
   - map_to_index:
-      by_builder: DashboardSpec.element
+      by_builder: Dashboard.element
 
-  # Append a single override instead forcing to define all of them at once
+  # Append a single override instead of forcing to define all of them at once
   - duplicate:
       by_name: VizConfigKind.overrides
       as: override
   - array_to_append:
       by_name: VizConfigKind.override
 
-  # Append a single variable instead forcing to define all of them at once
+  # Append a single variable instead of forcing to define all of them at once
   - duplicate:
-      by_builder: DashboardSpec.variables
+      by_builder: Dashboard.variables
       as: variable
   - array_to_append:
-      by_builder: DashboardSpec.variable
+      by_builder: Dashboard.variable

--- a/.cog/resources/dashboardv2/builder-transforms/common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/common.yaml
@@ -88,7 +88,7 @@ builders:
           - name: name
             type: &type_string
               kind: scalar
-              scalar: {scalar_kind: string}
+              scalar: { scalar_kind: string }
         assignments:
           - method: append
             path: spec.items
@@ -109,7 +109,8 @@ builders:
                                     value: { constant: ElementReference }
                                   - field: name
                                     value:
-                                      argument: { name: name, type: *type_string }
+                                      argument:
+                                        { name: name, type: *type_string }
 
   ##############
   # RowsLayout #
@@ -210,7 +211,22 @@ builders:
         - name: nextQueryId
           type:
             kind: scalar
-            scalar: {scalar_kind: uint32}
+            scalar: { scalar_kind: uint32 }
+
+  # Dataquery DataQueryKind composability
+  - compose:
+      by_variant: dataquery
+      source_builder_name: dashboardv2.DataQueryKind
+      composed_builder_name: Query
+      plugin_discriminator_field: group
+      composition_map: # Builder → assignment root path
+        __schema_entrypoint: spec
+      exclude_options: ["spec"]
+      rename_options:
+        # Avoid conflict with the datasource option in the panel schema
+        datasource: old_datasource
+
+  - omit: { by_name: DataQueryKind }
 
   ###################
   # Transformations #
@@ -263,9 +279,33 @@ builders:
       destination: VizConfigKind
       under_path: spec
 
+  # Panels VizConfigSpec composability
+  - compose:
+      by_variant: panelcfg
+      # this should run after the "dashboard" package has done its thing
+      # so these builders aren't needed anymore once the composition is done.
+      preserve_original_builders: false
+      source_builder_name: dashboardv2.VizConfigKind
+      composed_builder_name: Visualization
+      plugin_discriminator_field: group
+      composition_map: # Builder → assignment root path
+        Options: "spec.options"
+        FieldConfig: "spec.fieldConfig.defaults.custom"
+      exclude_options: [
+          "spec", # merged with another builder
+          "defaults", # merged with another builder
+          "fieldConfig", # merged with another builder
+          "options", # comes from a panel plugin
+          "custom", # comes from a panel plugin
+          "version", # TODO: check if it's relevant or not
+          "filterable", # TODO: check if it's relevant or not
+          "writeable", # TODO: check if it's relevant or not
+        ]
+
   - omit: { by_object: FieldConfig }
   - omit: { by_object: FieldConfigSource }
   - omit: { by_object: VizConfigSpec }
+  - omit: { by_name: VizConfigKind }
 
 options:
   - omit: { by_builder: LibraryPanel.spec }

--- a/.cog/resources/dashboardv2/builder-transforms/common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/common.yaml
@@ -214,6 +214,7 @@ builders:
       rename_options:
         # Avoid conflict with the datasource option in the panel schema
         datasource: old_datasource
+        labels: dataquery_labels
 
   - omit: { by_name: DataQueryKind }
 

--- a/.cog/resources/dashboardv2/builder-transforms/conditional-rendering.common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/conditional-rendering.common.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [all]
+
+package: dashboardv2
+
+builders:
+  #############################
+  # ConditionalRenderingGroup #
+  #############################
+
+  - merge_into:
+      source: ConditionalRenderingGroupSpec
+      destination: ConditionalRenderingGroupKind
+      under_path: spec
+  - rename:
+      by_object: ConditionalRenderingGroupKind
+      as: ConditionalRenderingGroup
+
+  - omit: { by_object: ConditionalRenderingGroupSpec }
+
+  ############################
+  # ConditionalRenderingData #
+  ############################
+
+  - merge_into:
+      source: ConditionalRenderingDataSpec
+      destination: ConditionalRenderingDataKind
+      under_path: spec
+  - rename:
+      by_object: ConditionalRenderingDataKind
+      as: ConditionalRenderingData
+
+  - omit: { by_object: ConditionalRenderingDataSpec }
+
+  #####################################
+  # ConditionalRenderingTimeRangeSize #
+  #####################################
+
+  - merge_into:
+      source: ConditionalRenderingTimeRangeSizeSpec
+      destination: ConditionalRenderingTimeRangeSizeKind
+      under_path: spec
+  - rename:
+      by_object: ConditionalRenderingTimeRangeSizeKind
+      as: ConditionalRenderingTimeRangeSize
+
+  - omit: { by_object: ConditionalRenderingTimeRangeSizeSpec }
+
+  ################################
+  # ConditionalRenderingVariable #
+  ################################
+
+  - merge_into:
+      source: ConditionalRenderingVariableSpec
+      destination: ConditionalRenderingVariableKind
+      under_path: spec
+  - rename:
+      by_object: ConditionalRenderingVariableKind
+      as: ConditionalRenderingVariable
+
+  - omit: { by_object: ConditionalRenderingVariableSpec }
+
+options:
+  - omit: { by_builder: ConditionalRenderingGroup.spec }
+  - omit: { by_builder: ConditionalRenderingData.spec }
+  - omit: { by_builder: ConditionalRenderingTimeRangeSize.spec }
+  - omit: { by_builder: ConditionalRenderingVariable.spec }
+
+  #############################
+  # ConditionalRenderingGroup #
+  #############################
+
+  # Append a single `element` value instead of a map of everything
+  - duplicate:
+      by_builder: ConditionalRenderingGroup.items
+      as: item
+  - array_to_append:
+      by_builder: ConditionalRenderingGroup.item

--- a/.cog/resources/dashboardv2/builder-transforms/factories.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/factories.yaml
@@ -10,7 +10,7 @@ builders:
   ############
 
   - add_factory:
-      by_name: DashboardSpec
+      by_name: Dashboard
       factory:
         name: manifest
         builder_ref: {referred_pkg: resource, referred_type: Manifest}
@@ -26,7 +26,7 @@ builders:
             name: spec
             type:
               kind: ref
-              ref: {referred_pkg: dashboardv2, referred_type: DashboardSpec}
+              ref: {referred_pkg: dashboardv2, referred_type: Dashboard}
         options:
           - name: apiVersion
             parameters:

--- a/.cog/resources/dashboardv2/builder-transforms/factories.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/factories.yaml
@@ -1,0 +1,130 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [all]
+
+package: dashboardv2
+
+builders:
+  ############
+  # Manifest #
+  ############
+
+  - add_factory:
+      by_name: DashboardSpec
+      factory:
+        name: manifest
+        builder_ref: {referred_pkg: resource, referred_type: Manifest}
+        comments:
+          - "Creates a resource manifest from a Dashboard."
+        arguments:
+          - &name_argument
+            name: name
+            type: &type_string
+              kind: scalar
+              scalar: {scalar_kind: string}
+          - &spec_argument
+            name: spec
+            type:
+              kind: ref
+              ref: {referred_pkg: dashboardv2, referred_type: DashboardSpec}
+        options:
+          - name: apiVersion
+            parameters:
+              - constant:
+                  value: "dashboard.grafana.app/v2"
+                  type: *type_string
+          - name: kind
+            parameters:
+              - constant:
+                  value: "Dashboard"
+                  type: *type_string
+          - name: metadata
+            parameters:
+              - factory:
+                  ref: { package: resource, builder: Metadata, factory: named }
+                  parameters:
+                    - { argument: *name_argument }
+          - name: spec
+            parameters:
+              - { argument: *spec_argument, force_build: true }
+
+  ##############
+  # RowsLayout #
+  ##############
+
+  - add_factory:
+      by_name: Rows
+      factory:
+        name: rows
+
+  - add_factory:
+      by_name: Row
+      factory:
+        name: row
+        arguments:
+          - &title_argument
+            name: title
+            type: *type_string
+        options:
+          - name: title
+            parameters:
+              - { argument: *title_argument }
+
+  ##################
+  # AutoGridLayout #
+  ##################
+
+  - add_factory:
+      by_name: AutoGrid
+      factory:
+        name: autoGrid
+
+  - add_factory:
+      by_name: AutoGridItem
+      factory:
+        name: autoGridItem
+        arguments:
+          - *name_argument
+        options:
+          - &name_option
+            name: name
+            parameters:
+              - { argument: *name_argument }
+
+  ##############
+  # TabsLayout #
+  ##############
+
+  - add_factory:
+      by_name: Tabs
+      factory:
+        name: tabs
+
+  - add_factory:
+      by_name: Tab
+      factory:
+        name: tab
+        arguments:
+          - *title_argument
+        options:
+          - name: title
+            parameters:
+              - { argument: *title_argument }
+
+  ##############
+  # GridLayout #
+  ##############
+
+  - add_factory:
+      by_name: Grid
+      factory:
+        name: grid
+
+  - add_factory:
+      by_name: GridItem
+      factory:
+        name: gridItem
+        arguments:
+          - *name_argument
+        options:
+          - *name_option

--- a/.cog/resources/dashboardv2/builder-transforms/no-disjunctions.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/no-disjunctions.yaml
@@ -1,0 +1,123 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [go, java]
+
+package: dashboardv2
+
+# Some special treatment for languages without proper union types
+
+options:
+  ###########
+  # Layouts #
+  ###########
+
+  # GridLayoutKind + RowsLayoutKind + AutoGridLayoutKind + TabsLayoutKind
+  - disjunction_as_options:
+      by_builder: DashboardSpec.Layout
+  - rename:
+      by_builder: DashboardSpec.GridLayoutKind
+      as: gridLayout
+  - rename:
+      by_builder: DashboardSpec.RowsLayoutKind
+      as: rowsLayout
+  - rename:
+      by_builder: DashboardSpec.AutoGridLayoutKind
+      as: autoGridLayout
+  - rename:
+      by_builder: DashboardSpec.TabsLayoutKind
+      as: tabsLayout
+
+  ##############
+  # RowsLayout #
+  ##############
+
+  # GridLayoutKind + AutoGridLayoutKind + TabsLayoutKind + RowsLayoutKind
+  - disjunction_as_options:
+      by_builder: row.Layout
+  - rename:
+      by_builder: row.GridLayoutKind
+      as: gridLayout
+  - rename:
+      by_builder: row.AutoGridLayoutKind
+      as: autoGridLayout
+  - rename:
+      by_builder: row.TabsLayoutKind
+      as: tabsLayout
+  - rename:
+      by_builder: row.RowsLayoutKind
+      as: rowsLayout
+
+  ##############
+  # TabsLayout #
+  ##############
+
+  # GridLayoutKind + AutoGridLayoutKind + TabsLayoutKind + RowsLayoutKind
+  - disjunction_as_options:
+      by_builder: Tab.Layout
+  - rename:
+      by_builder: Tab.GridLayoutKind
+      as: gridLayout
+  - rename:
+      by_builder: Tab.AutoGridLayoutKind
+      as: autoGridLayout
+  - rename:
+      by_builder: Tab.TabsLayoutKind
+      as: tabsLayout
+  - rename:
+      by_builder: Tab.RowsLayoutKind
+      as: rowsLayout
+
+  ##############
+  # Dashboards #
+  ##############
+
+  # panel + library panel
+  - disjunction_as_options:
+      by_builder: DashboardSpec.element
+      argument_index: 1
+  - rename:
+      by_builder: DashboardSpec.PanelKind
+      as: panel
+  - rename:
+      by_builder: DashboardSpec.LibraryPanelKind
+      as: libraryPanel
+
+  #############
+  # Variables #
+  #############
+
+  - disjunction_as_options:
+      by_builder: DashboardSpec.variable
+  - rename:
+      by_builder: DashboardSpec.QueryVariableKind
+      as: queryVariable
+  - rename:
+      by_builder: DashboardSpec.TextVariableKind
+      as: textVariable
+  - rename:
+      by_builder: DashboardSpec.ConstantVariableKind
+      as: constantVariable
+  - rename:
+      by_builder: DashboardSpec.DatasourceVariableKind
+      as: datasourceVariable
+  - rename:
+      by_builder: DashboardSpec.IntervalVariableKind
+      as: intervalVariable
+  - rename:
+      by_builder: DashboardSpec.CustomVariableKind
+      as: customVariable
+  - rename:
+      by_builder: DashboardSpec.GroupByVariableKind
+      as: groupByVariable
+  - rename:
+      by_builder: DashboardSpec.AdhocVariableKind
+      as: adhocVariable
+
+  ##########
+  # Panels #
+  ##########
+
+  # WithOverride(matcher, properties) instead of WithOverride(struct{...})
+  - struct_fields_as_arguments:
+      by_name: VizConfigKind.override
+      fields: [matcher, properties]

--- a/.cog/resources/dashboardv2/builder-transforms/no-disjunctions.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/no-disjunctions.yaml
@@ -13,18 +13,18 @@ options:
 
   # GridLayoutKind + RowsLayoutKind + AutoGridLayoutKind + TabsLayoutKind
   - disjunction_as_options:
-      by_builder: DashboardSpec.Layout
+      by_builder: Dashboard.Layout
   - rename:
-      by_builder: DashboardSpec.GridLayoutKind
+      by_builder: Dashboard.GridLayoutKind
       as: gridLayout
   - rename:
-      by_builder: DashboardSpec.RowsLayoutKind
+      by_builder: Dashboard.RowsLayoutKind
       as: rowsLayout
   - rename:
-      by_builder: DashboardSpec.AutoGridLayoutKind
+      by_builder: Dashboard.AutoGridLayoutKind
       as: autoGridLayout
   - rename:
-      by_builder: DashboardSpec.TabsLayoutKind
+      by_builder: Dashboard.TabsLayoutKind
       as: tabsLayout
 
   ##############
@@ -73,13 +73,13 @@ options:
 
   # panel + library panel
   - disjunction_as_options:
-      by_builder: DashboardSpec.element
+      by_builder: Dashboard.element
       argument_index: 1
   - rename:
-      by_builder: DashboardSpec.PanelKind
+      by_builder: Dashboard.PanelKind
       as: panel
   - rename:
-      by_builder: DashboardSpec.LibraryPanelKind
+      by_builder: Dashboard.LibraryPanelKind
       as: libraryPanel
 
   #############
@@ -87,30 +87,30 @@ options:
   #############
 
   - disjunction_as_options:
-      by_builder: DashboardSpec.variable
+      by_builder: Dashboard.variable
   - rename:
-      by_builder: DashboardSpec.QueryVariableKind
+      by_builder: Dashboard.QueryVariableKind
       as: queryVariable
   - rename:
-      by_builder: DashboardSpec.TextVariableKind
+      by_builder: Dashboard.TextVariableKind
       as: textVariable
   - rename:
-      by_builder: DashboardSpec.ConstantVariableKind
+      by_builder: Dashboard.ConstantVariableKind
       as: constantVariable
   - rename:
-      by_builder: DashboardSpec.DatasourceVariableKind
+      by_builder: Dashboard.DatasourceVariableKind
       as: datasourceVariable
   - rename:
-      by_builder: DashboardSpec.IntervalVariableKind
+      by_builder: Dashboard.IntervalVariableKind
       as: intervalVariable
   - rename:
-      by_builder: DashboardSpec.CustomVariableKind
+      by_builder: Dashboard.CustomVariableKind
       as: customVariable
   - rename:
-      by_builder: DashboardSpec.GroupByVariableKind
+      by_builder: Dashboard.GroupByVariableKind
       as: groupByVariable
   - rename:
-      by_builder: DashboardSpec.AdhocVariableKind
+      by_builder: Dashboard.AdhocVariableKind
       as: adhocVariable
 
   ##########

--- a/.cog/resources/dashboardv2/builder-transforms/overrides.common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/overrides.common.yaml
@@ -2,7 +2,7 @@
 
 languages: [all]
 
-package: '*'
+package: dashboardv2
 
 builders:
   #######################

--- a/.cog/resources/dashboardv2/builder-transforms/overrides.common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/overrides.common.yaml
@@ -1,0 +1,140 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [all]
+
+package: '*'
+
+builders:
+  #######################
+  # Overrides shortcuts #
+  #######################
+
+  # byName
+  - add_option:
+      by_object: VizConfigKind
+      option:
+        name: overrideByName
+        comments:
+          - Adds override rules for a specific field, referred to by its name.
+        arguments:
+          - name: name
+            type: &type_string
+              kind: scalar
+              scalar: {scalar_kind: string}
+          - name: properties
+            type: &type_DynamicConfigValue_array
+              kind: array
+              array: {value_type: {kind: ref, ref: {referred_pkg: dashboardv2, referred_type: DynamicConfigValue}}}
+        assignments:
+          - method: append
+            path: spec.fieldConfig.overrides
+            value:
+              envelope:
+                values:
+                  # Matcher
+                  - field: matcher
+                    value:
+                      envelope:
+                        values:
+                          - field: id
+                            value: {constant: byName}
+                          - field: options
+                            value: {argument: {name: name, type: *type_string}}
+                  # Properties
+                  - field: properties
+                    value:
+                      argument: { name: properties, type: *type_DynamicConfigValue_array }
+
+  # byRegexp
+  - add_option:
+      by_object: VizConfigKind
+      option:
+        name: overrideByRegexp
+        comments:
+          - Adds override rules for the fields whose name match the given regexp.
+        arguments:
+          - name: regexp
+            type: *type_string
+          - name: properties
+            type: *type_DynamicConfigValue_array
+        assignments:
+          - method: append
+            path: spec.fieldConfig.overrides
+            value:
+              envelope:
+                values:
+                  # Matcher
+                  - field: matcher
+                    value:
+                      envelope:
+                        values:
+                          - field: id
+                            value: {constant: byRegexp}
+                          - field: options
+                            value: {argument: {name: regexp, type: *type_string}}
+                  # Properties
+                  - field: properties
+                    value:
+                      argument: {name: properties, type: *type_DynamicConfigValue_array}
+
+  # byType
+  - add_option:
+      by_object: VizConfigKind
+      option:
+        name: overrideByFieldType
+        comments:
+          - Adds override rules for all the fields of the given type.
+        arguments:
+          - name: fieldType
+            type: *type_string
+          - name: properties
+            type: *type_DynamicConfigValue_array
+        assignments:
+          - method: append
+            path: spec.fieldConfig.overrides
+            value:
+              envelope:
+                values:
+                  # Matcher
+                  - field: matcher
+                    value:
+                      envelope:
+                        values:
+                          - field: id
+                            value: {constant: byType}
+                          - field: options
+                            value: {argument: {name: fieldType, type: *type_string}}
+                  # Properties
+                  - field: properties
+                    value:
+                      argument: {name: properties, type: *type_DynamicConfigValue_array}
+
+  # byFrameRefID
+  - add_option:
+      by_object: VizConfigKind
+      option:
+        name: overrideByQuery
+        arguments:
+          - name: queryRefId
+            type: *type_string
+          - name: properties
+            type: *type_DynamicConfigValue_array
+        assignments:
+          - method: append
+            path: spec.fieldConfig.overrides
+            value:
+              envelope:
+                values:
+                  # Matcher
+                  - field: matcher
+                    value:
+                      envelope:
+                        values:
+                          - field: id
+                            value: {constant: byFrameRefID}
+                          - field: options
+                            value: {argument: {name: queryRefId, type: *type_string}}
+                  # Properties
+                  - field: properties
+                    value:
+                      argument: {name: properties, type: *type_DynamicConfigValue_array}

--- a/.cog/resources/dashboardv2/builder-transforms/variables.common.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/variables.common.yaml
@@ -1,0 +1,154 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [all]
+
+package: dashboardv2
+
+builders:
+  - omit: { by_object: VariableOption }
+
+  #################
+  # QueryVariable #
+  #################
+  - merge_into:
+      source: QueryVariableSpec
+      destination: QueryVariableKind
+      under_path: spec
+  - omit: { by_object: QueryVariableSpec }
+  - rename:
+      by_object: QueryVariableKind
+      as: QueryVariable
+  - promote_options_to_constructor:
+      by_name: QueryVariable
+      options: [name]
+
+  ################
+  # TextVariable #
+  ################
+  - merge_into:
+      source: TextVariableSpec
+      destination: TextVariableKind
+      under_path: spec
+  - omit: { by_object: TextVariableSpec }
+  - rename:
+      by_object: TextVariableKind
+      as: TextVariable
+  - promote_options_to_constructor:
+      by_name: TextVariable
+      options: [name]
+
+  ####################
+  # ConstantVariable #
+  ####################
+  - merge_into:
+      source: ConstantVariableSpec
+      destination: ConstantVariableKind
+      under_path: spec
+  - omit: { by_object: ConstantVariableSpec }
+  - rename:
+      by_object: ConstantVariableKind
+      as: ConstantVariable
+  - promote_options_to_constructor:
+      by_name: ConstantVariable
+      options: [name]
+
+  ######################
+  # DatasourceVariable #
+  ######################
+  - merge_into:
+      source: DatasourceVariableSpec
+      destination: DatasourceVariableKind
+      under_path: spec
+  - omit: { by_object: DatasourceVariableSpec }
+  - rename:
+      by_object: DatasourceVariableKind
+      as: DatasourceVariable
+  - promote_options_to_constructor:
+      by_name: DatasourceVariable
+      options: [name]
+
+  ####################
+  # IntervalVariable #
+  ####################
+  - merge_into:
+      source: IntervalVariableSpec
+      destination: IntervalVariableKind
+      under_path: spec
+  - omit: { by_object: IntervalVariableSpec }
+  - rename:
+      by_object: IntervalVariableKind
+      as: IntervalVariable
+  - promote_options_to_constructor:
+      by_name: IntervalVariable
+      options: [name]
+
+  ##################
+  # CustomVariable #
+  ##################
+  - merge_into:
+      source: CustomVariableSpec
+      destination: CustomVariableKind
+      under_path: spec
+  - omit: { by_object: CustomVariableSpec }
+  - rename:
+      by_object: CustomVariableKind
+      as: CustomVariable
+  - promote_options_to_constructor:
+      by_name: CustomVariable
+      options: [name]
+
+  ###################
+  # GroupByVariable #
+  ###################
+  - merge_into:
+      source: GroupByVariableSpec
+      destination: GroupByVariableKind
+      under_path: spec
+  - omit: { by_object: GroupByVariableSpec }
+  - rename:
+      by_object: GroupByVariableKind
+      as: GroupByVariable
+  - promote_options_to_constructor:
+      by_name: GroupByVariable
+      options: [name]
+
+  #################
+  # AdhocVariable #
+  #################
+  - merge_into:
+      source: AdhocVariableSpec
+      destination: AdhocVariableKind
+      under_path: spec
+  - omit: { by_object: AdhocVariableSpec }
+  - rename:
+      by_object: AdhocVariableKind
+      as: AdhocVariable
+  - promote_options_to_constructor:
+      by_name: AdhocVariable
+      options: [name]
+
+  ##################
+  # SwitchVariable #
+  ##################
+  - merge_into:
+      source: SwitchVariableSpec
+      destination: SwitchVariableKind
+      under_path: spec
+  - omit: { by_object: SwitchVariableSpec }
+  - rename:
+      by_object: SwitchVariableKind
+      as: SwitchVariable
+  - promote_options_to_constructor:
+      by_name: SwitchVariable
+      options: [name]
+
+options:
+  - omit: { by_builder: QueryVariable.spec }
+  - omit: { by_builder: TextVariable.spec }
+  - omit: { by_builder: ConstantVariable.spec }
+  - omit: { by_builder: DatasourceVariable.spec }
+  - omit: { by_builder: IntervalVariable.spec }
+  - omit: { by_builder: CustomVariable.spec }
+  - omit: { by_builder: GroupByVariable.spec }
+  - omit: { by_builder: AdhocVariable.spec }
+  - omit: { by_builder: SwitchVariable.spec }

--- a/.cog/resources/dashboardv2/config.yaml
+++ b/.cog/resources/dashboardv2/config.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/unit.json
+
+# See https://grafana.github.io/cog/pipelines/splitting_pipeline/
+
+inputs:
+  - cue:
+      url: 'https://raw.githubusercontent.com/grafana/grafana/main/apps/dashboard/kinds/v2/dashboard_spec.cue'
+
+      # Name of the package in which code for this resource will be generated.
+      package: dashboardv2
+
+      transformations:
+        - '%__config_dir%/schema.transforms.yaml'
+
+builder_transformations:
+  - '%__config_dir%/builder-transforms'

--- a/.cog/resources/dashboardv2/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2/schema.transforms.yaml
@@ -14,3 +14,27 @@ passes:
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "Dashboard" }
+
+  # Keep ControlSourceRef as a concrete struct for all generators.
+  # Without this, some language backends treat it as an alias/disjunction and
+  # emit invalid (array -> object) conversions in generated unmarshallers.
+  - retype_object:
+      object: dashboardv2.ControlSourceRef
+      comments:
+        - Source information for controls (e.g. variables or links)
+      as:
+        kind: struct
+        struct:
+          fields:
+            - name: type
+              required: true
+              type:
+                kind: scalar
+                scalar: { scalar_kind: string, value: datasource }
+            - name: group
+              required: true
+              comments:
+                - The plugin type-id
+              type:
+                kind: scalar
+                scalar: { scalar_kind: string }

--- a/.cog/resources/dashboardv2/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2/schema.transforms.yaml
@@ -15,26 +15,120 @@ passes:
         kind: scalar
         scalar: { scalar_kind: string, value: "Dashboard" }
 
-  # Keep ControlSourceRef as a concrete struct for all generators.
-  # Without this, some language backends treat it as an alias/disjunction and
-  # emit invalid (array -> object) conversions in generated unmarshallers.
+  ################
+  # Dashboard v2 #
+  ################
+
+  # Some future-proofing
+  - constant_to_enum:
+      objects:
+        - dashboardv2.RepeatMode
+
+  ##############
+  # Composable #
+  ##############
+  
+  # VizConfigSpec.options, FieldConfig.custom and DataqueryKind.spec are retyped to any.
+  # The purpose of this is to make them generic to be able to cast to the proper plugin/dataquery
+  # and be able to set the values defined in these schemas.
+  
+  - retype_field:
+      field: dashboardv2.VizConfigSpec.options
+      as:
+        kind: scalar
+        scalar: { scalar_kind: any }
+        nullable: true
+
+  - retype_field:
+      field: dashboardv2.FieldConfig.custom
+      as:
+        kind: scalar
+        scalar: { scalar_kind: any }
+        nullable: true
+
+  - retype_field:
+      field: dashboardv2.DataQueryKind.spec
+      as:
+        kind: scalar
+        scalar: { scalar_kind: any }
+        nullable: true
+
+
+  # Is this object meant for frontend usage only?
+  - omit:
+      objects: [ dashboardv2.VariableCustomFormatterFn ]
+
+  - retype_field:
+      field: dashboardv2.CustomVariableValue.formatter
+      as:
+        kind: scalar
+        scalar: { scalar_kind: string }
+        nullable: true
+
+  - rename_object:
+      from: dashboardv2.DashboardSpec
+      to: Dashboard
+
+  # To get rid of the default value (each panel query needs a unique refId, and
+  # an empty value as default makes it easier to identify that a unique refId
+  # needs to be computed)
+  - retype_field:
+      field: dashboardv2.PanelQuerySpec.refId
+      as:
+        kind: scalar
+        scalar:
+          scalar_kind: string
+
+  #####################
+  # FieldConfigSource #
+  #####################
+
+  # Relates to https://github.com/grafana/grafana-foundation-sdk/issues/664
+  # We have to duplicate the entire definition of dashboard.FieldConfigSource
+  # just to add the `__systemRef` field since overrides are defined as an
+  # anonymous struct.
   - retype_object:
-      object: dashboardv2.ControlSourceRef
+      object: dashboardv2.FieldConfigSource
       comments:
-        - Source information for controls (e.g. variables or links)
+        - The data model used in Grafana, namely the data frame, is a columnar-oriented table structure that unifies both time series and table query results.
+        - Each column within this structure is called a field. A field can represent a single time series or table column.
+        - Field options allow you to change how the data is displayed in your visualizations.
       as:
         kind: struct
         struct:
           fields:
-            - name: type
-              required: true
-              type:
-                kind: scalar
-                scalar: { scalar_kind: string, value: datasource }
-            - name: group
+            - name: defaults
               required: true
               comments:
-                - The plugin type-id
+                - Defaults are the options applied to all fields.
               type:
-                kind: scalar
-                scalar: { scalar_kind: string }
+                kind: ref
+                ref: { referred_pkg: dashboardv2, referred_type: FieldConfig }
+            - name: overrides
+              required: true
+              comments:
+                - Overrides are the options applied to specific fields overriding the defaults.
+              type:
+                kind: array
+                array:
+                  value_type:
+                    kind: struct
+                    struct:
+                      fields:
+                        - name: __systemRef
+                          type:
+                            kind: scalar
+                            scalar: { scalar_kind: string }
+                        - name: matcher
+                          required: true
+                          type:
+                            kind: ref
+                            ref: { referred_pkg: dashboardv2, referred_type: MatcherConfig }
+                        - name: properties
+                          required: true
+                          type:
+                            kind: array
+                            array:
+                              value_type:
+                                kind: ref
+                                ref: { referred_pkg: dashboardv2, referred_type: DynamicConfigValue }

--- a/.cog/resources/dashboardv2/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2/schema.transforms.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/compiler_passes.json
+
+# See https://grafana.github.io/cog/pipelines/schema_transformations/
+passes:
+  # Add a few useful constants
+  - add_object:
+      object: dashboardv2.DashboardAPIVersion
+      as:
+        kind: scalar
+        scalar: { scalar_kind: string, value: "dashboard.grafana.app/v2" }
+
+  - add_object:
+      object: dashboardv2.DashboardKind
+      as:
+        kind: scalar
+        scalar: { scalar_kind: string, value: "Dashboard" }

--- a/.cog/resources/dashboardv2beta1/builder-transforms/common.yaml
+++ b/.cog/resources/dashboardv2beta1/builder-transforms/common.yaml
@@ -284,7 +284,6 @@ builders:
       by_variant: panelcfg
       # this should run after the "dashboard" package has done its thing
       # so these builders aren't needed anymore once the composition is done.
-      preserve_original_builders: false
       source_builder_name: dashboardv2beta1.VizConfigKind
       composed_builder_name: Visualization
       plugin_discriminator_field: group

--- a/.cog/resources/dashboardv2beta1/builder-transforms/overrides.common.yaml
+++ b/.cog/resources/dashboardv2beta1/builder-transforms/overrides.common.yaml
@@ -2,7 +2,7 @@
 
 languages: [all]
 
-package: '*'
+package: dashboardv2beta1
 
 builders:
   #######################

--- a/.cog/resources/datasource/builder-transforms/python.yaml
+++ b/.cog/resources/datasource/builder-transforms/python.yaml
@@ -8,3 +8,7 @@ options:
   - rename_arguments:
       by_builder: Query.datasource
       as: [ ref ]
+
+  - rename_arguments:
+      by_builder: QueryV2.datasource
+      as: [ ref ]

--- a/.cog/resources/datasource/builder-transforms/ts.yaml
+++ b/.cog/resources/datasource/builder-transforms/ts.yaml
@@ -8,3 +8,7 @@ options:
   - rename_arguments:
       by_builder: Query.datasource
       as: [ ref ]
+
+  - rename_arguments:
+      by_builder: QueryV2.datasource
+      as: [ ref ]

--- a/.cog/resources/old_datasource.builder.transforms.yaml
+++ b/.cog/resources/old_datasource.builder.transforms.yaml
@@ -6,3 +6,4 @@ package: "*"
 
 options:
   - omit: { by_builder: Query.old_datasource }
+  - omit: { by_builder: QueryV2.old_datasource }

--- a/.cog/resources/statetimeline/common.builder.transforms.yaml
+++ b/.cog/resources/statetimeline/common.builder.transforms.yaml
@@ -56,3 +56,31 @@ builders:
                   kind: scalar
                   scalar: {scalar_kind: float64}
             value: {constant: null}
+
+  - add_option:
+      by_name: VisualizationV2
+      option:
+        name: disablePagination
+        comments:
+          - Disables the pagination.
+        assignments:
+          - method: direct
+            # we have to explicitly build this path since `options` is `any`
+            # and needs to be type hinted.
+            path_obj:
+              - identifier: spec
+                type:
+                  kind: ref
+                  ref: { referred_pkg: dashboardv2, referred_type: VizConfigSpec }
+              - identifier: options
+                type:
+                  kind: scalar
+                  scalar: { scalar_kind: any }
+                typehint:
+                  kind: ref
+                  ref: { referred_pkg: statetimeline, referred_type: Options }
+              - identifier: perPage
+                type:
+                  kind: scalar
+                  scalar: { scalar_kind: float64 }
+            value: { constant: null }

--- a/.cog/templates/go/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl
@@ -1,0 +1,42 @@
+{{- define "object_dashboardv2_DataQueryKind_custom_unmarshal" }}
+{{- $fmt := importStdPkg "fmt" -}}
+{{- $json := importStdPkg "encoding/json" -}}
+func (resource *{{ .Object.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	{{- range $field := .Object.Type.Struct.Fields }}
+	{{- if eq $field.Name "spec" }}
+	{{ continue }}
+	{{- else }}
+	if fields["{{ $field.Name }}"] != nil {
+		if err := json.Unmarshal(fields["{{ $field.Name }}"], &resource.{{ $field.Name|upperCamelCase }}); err != nil {
+			return fmt.Errorf("error decoding field '{{ $field.Name }}': %w", err)
+		}
+	}
+	{{- end }}
+	{{- end }}
+
+	{{ template "unmarshal_dashboardv2_DataQueryKind_spec" }}
+
+	return nil
+}
+
+{{ end }}
+
+{{- define "unmarshal_dashboardv2_DataQueryKind_spec" -}}
+	{{- $fmt := importStdPkg "fmt" -}}
+	{{- $cog := importPkg "cog" }}
+	if fields["spec"] != nil {
+		dataquery, err := cog.UnmarshalDataquery(fields["spec"], resource.Group)
+		if err != nil {
+			return fmt.Errorf("error decoding field 'spec': %w", err)
+		}
+		resource.Spec = dataquery
+	}
+{{- end -}}

--- a/.cog/templates/go/overrides/object_dashboardv2_DataQueryKind_field_spec_custom_strict_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2_DataQueryKind_field_spec_custom_strict_unmarshal.tmpl
@@ -1,0 +1,9 @@
+{{- define "object_dashboardv2_DataQueryKind_field_spec_custom_strict_unmarshal" -}}
+	{{- $cog := importPkg "cog" -}}
+	dataquery, err := cog.UnmarshalDataquery(fields["spec"], resource.Group)
+	if err != nil {
+		errs = append(errs, cog.MakeBuildErrors("spec", err)...)
+	} else {
+		resource.Spec = dataquery
+	}
+{{- end }}

--- a/.cog/templates/go/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
@@ -1,0 +1,100 @@
+{{- define "object_dashboardv2_VizConfigKind_custom_unmarshal" }}
+{{- $fmt := importStdPkg "fmt" -}}
+{{- $json := importStdPkg "encoding/json" -}}
+func (resource *{{ .Object.Name|formatObjectName }}) UnmarshalJSON(raw []byte) error {
+    if raw == nil {
+        return nil
+    }
+
+    fields := make(map[string]json.RawMessage)
+    if err := json.Unmarshal(raw, &fields); err != nil {
+        return err
+    }
+    {{- range $field := .Object.Type.Struct.Fields }}
+	if fields["{{ $field.Name }}"] != nil {
+	{{- if eq $field.Name "spec" }}
+		{{ template "object_dashboardv2_VizConfigKind_spec" (dict "Field" $field) }}
+	{{- else }}
+		if err := json.Unmarshal(fields["{{ $field.Name }}"], &resource.{{ $field.Name|formatFieldName }}); err != nil {
+			return fmt.Errorf("error decoding field '{{ $field.Name }}': %w", err)
+		}
+    {{- end }}
+	}
+    {{- end }}
+
+    return nil
+}
+
+{{ end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec" -}}
+	{{- $fmt := importStdPkg "fmt" -}}
+	{{- $json := importStdPkg "encoding/json" -}}
+	spec := {{ .Field.Type|formatType }}{}
+	specFields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(fields["spec"], &specFields); err != nil {
+		return err
+	}
+
+	{{ range $field := (.Field.Type|resolveRefs).Struct.Fields }}
+		if specFields["{{ $field.Name }}"] != nil {
+		{{- if eq $field.Name "options" }}
+			{{ template "object_dashboardv2_VizConfigKind_spec_options" }}
+		{{- else if eq $field.Name "fieldConfig" }}
+			{{ template "object_dashboardv2_VizConfigKind_spec_fieldConfig" }}
+		{{- else }}
+			if err := json.Unmarshal(specFields["{{ $field.Name }}"], &spec.{{ $field.Name|formatFieldName }}); err != nil {
+				return fmt.Errorf("error decoding field 'spec.{{ $field.Name }}': %w", err)
+			}
+		{{- end }}
+		}
+	{{ end }}
+	resource.Spec = spec
+{{- end -}}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_fieldConfig" -}}
+	{{- $fmt := importStdPkg "fmt" -}}
+	{{- $json := importStdPkg "encoding/json" -}}
+	{{- $cog := importPkg "cog" -}}
+	if err := json.Unmarshal(specFields["fieldConfig"], &spec.FieldConfig); err != nil {
+		return fmt.Errorf("error decoding field 'fieldConfig': %w", err)
+	}
+
+	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
+	if found && variantCfg.FieldConfigUnmarshaler != nil {
+		fakeFieldConfigSource := struct {
+			Defaults struct {
+				Custom json.RawMessage `json:"custom"`
+			} `json:"defaults"`
+		}{}
+		if err := json.Unmarshal(specFields["fieldConfig"], &fakeFieldConfigSource); err != nil {
+			return err
+		}
+
+		if fakeFieldConfigSource.Defaults.Custom != nil {
+			customFieldConfig, err := variantCfg.FieldConfigUnmarshaler(fakeFieldConfigSource.Defaults.Custom)
+			if err != nil {
+				return err
+			}
+
+			spec.FieldConfig.Defaults.Custom = customFieldConfig
+		}
+	}
+{{- end -}}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_options" -}}
+	{{- $json := importStdPkg "encoding/json" -}}
+	{{- $cog := importPkg "cog" -}}
+	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
+	if found && variantCfg.OptionsUnmarshaler != nil {
+		options, err := variantCfg.OptionsUnmarshaler(specFields["options"])
+		if err != nil {
+			return err
+		}
+		spec.Options = options
+	} else {
+		if err := json.Unmarshal(specFields["options"], &spec.Options); err != nil {
+			return err
+		}
+	}
+{{- end -}}

--- a/.cog/templates/go/overrides/object_dashboardv2_VizConfigKind_field_spec_custom_strict_unmarshal.tmpl
+++ b/.cog/templates/go/overrides/object_dashboardv2_VizConfigKind_field_spec_custom_strict_unmarshal.tmpl
@@ -1,0 +1,73 @@
+{{- define "object_dashboardv2_VizConfigKind_field_spec_custom_strict_unmarshal" -}}
+	{{- $fmt := importStdPkg "fmt" -}}
+	{{- $json := importStdPkg "encoding/json" -}}
+	{{- $cog := importPkg "cog" -}}
+	spec := {{ .Field.Type|formatType }}{}
+	specFields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(fields["spec"], &specFields); err != nil {
+		errs = append(errs, cog.MakeBuildErrors("spec", err)...)
+	} else {
+		{{- range $field := (.Field.Type|resolveRefs).Struct.Fields }}
+			if specFields["{{ $field.Name }}"] != nil {
+			{{- if eq $field.Name "options" }}
+				{{ template "object_dashboardv2_VizConfigKind_spec_options_strict_unmarshal" }}
+			{{- else if eq $field.Name "fieldConfig" }}
+				{{ template "object_dashboardv2_VizConfigKind_spec_fieldConfig" }}
+			{{- else }}
+				{{- $inputRef := print "specFields[" ($field.Name|formatScalar) "]" }}
+				{{- $unmarshalInto := print "spec." ($field.Name|formatFieldName) }}
+				{{- $errorBreadcrumb := print "spec." $field.Name }}
+				{{ template "strict_unmarshal_field_type" (dict "RawInputRef" $inputRef "InputType" $field.Type "UnmarshalInto" $unmarshalInto "ErrorBreadcrumb" $errorBreadcrumb "Depth" 1) }}
+			{{- end }}
+			}
+		{{ end }}
+	}
+
+	resource.Spec = spec
+{{ end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_fieldConfig_strict_unmarshal" -}}
+	{{- $fmt := importStdPkg "fmt" -}}
+	{{- $json := importStdPkg "encoding/json" -}}
+	{{- $cog := importPkg "cog" -}}
+	if err := json.Unmarshal(specFields["fieldConfig"], &spec.FieldConfig); err != nil {
+		errs = append(errs, cog.MakeBuildErrors("spec.fieldConfig", err)...)
+	} else {
+		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
+		if found && variantCfg.StrictFieldConfigUnmarshaler != nil {
+			fakeFieldConfigSource := struct {
+				Defaults struct {
+					Custom json.RawMessage `json:"custom"`
+				} `json:"defaults"`
+			}{}
+			if err := json.Unmarshal(specFields["fieldConfig"], &fakeFieldConfigSource); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("spec.fieldConfig", err)...)
+			} else if fakeFieldConfigSource.Defaults.Custom != nil {
+				customFieldConfig, err := variantCfg.StrictFieldConfigUnmarshaler(fakeFieldConfigSource.Defaults.Custom)
+				if err != nil {
+					errs = append(errs, cog.MakeBuildErrors("spec.fieldConfig.defaults.custom", err)...)
+				} else {
+					spec.FieldConfig.Defaults.Custom = customFieldConfig
+				}
+			}
+		}
+	}
+{{- end -}}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_options_strict_unmarshal" -}}
+	{{- $json := importStdPkg "encoding/json" -}}
+	{{- $cog := importPkg "cog" -}}
+	variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Group)
+	if found && variantCfg.StrictOptionsUnmarshaler != nil {
+		options, err := variantCfg.StrictOptionsUnmarshaler(specFields["options"])
+		if err != nil {
+			errs = append(errs, cog.MakeBuildErrors("spec.options", err)...)
+		} else {
+			spec.Options = options
+		}
+	} else {
+		if err := json.Unmarshal(specFields["options"], &spec.Options); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("spec.options", err)...)
+		}
+	}
+{{- end -}}

--- a/.cog/templates/go/overrides/schema_variant_dataquery.tmpl
+++ b/.cog/templates/go/overrides/schema_variant_dataquery.tmpl
@@ -54,14 +54,28 @@ func VariantConfig() variants.DataqueryConfig {
                 return {{ .Schema.EntryPoint|formatObjectName }}Converter(dataquery)
             {{- end }}
         },
-        {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
-        {{- $dashboardv2beta1 := importPkg "dashboardv2beta1" }}
+        {{- $hasBeta := objectExists "dashboardv2beta1" "DataQueryKind" -}}
+        {{- $hasV2 := objectExists "dashboardv2" "DataQueryKind" -}}
+        {{- if or $hasV2 $hasBeta }}
         GoV2Converter: func(input any) string {
+            {{- if $hasBeta }}
+            {{- $dashboardv2beta1 := importPkg "dashboardv2beta1" }}
             if cast, ok := input.(*dashboardv2beta1.DataQueryKind); ok {
                 return QueryConverter(*cast)
+            } else if cast, ok := input.(dashboardv2beta1.DataQueryKind); ok {
+                return QueryConverter(cast)
             }
-   
-            return QueryConverter(input.(dashboardv2beta1.DataQueryKind))
+            {{- end }}
+            {{- if $hasV2 }}
+            {{- $dashboardv2 := importPkg "dashboardv2" }}
+            if cast, ok := input.(*dashboardv2.DataQueryKind); ok {
+                return QueryV2Converter(*cast)
+            } else if cast, ok := input.(dashboardv2.DataQueryKind); ok {
+                return QueryV2Converter(cast)
+            }
+            {{- end }}
+            
+            return "/* could not convert DataQueryKind */"
         },
         {{- end }}
         {{- end }}

--- a/.cog/templates/go/overrides/schema_variant_panelcfg.tmpl
+++ b/.cog/templates/go/overrides/schema_variant_panelcfg.tmpl
@@ -62,16 +62,32 @@ func VariantConfig() {{ $variants }}.PanelcfgConfig {
 			if panel, ok := inputPanel.(*{{ $dashboard }}.Panel); ok {
 				return PanelConverter(*panel)
 			}
-            {{- if objectExists "dashboardv2beta1" "VizConfigKind" }}
+			
+			{{- $hasBeta := objectExists "dashboardv2beta1" "VizConfigKind" -}}
+            {{- $hasV2 := objectExists "dashboardv2" "VizConfigKind" -}}
+			
+			{{- if $hasBeta }}
             {{- $dashboardv2beta1 := importPkg "dashboardv2beta1" }}
-            if panel, ok := inputPanel.(dashboard.Panel); ok {
-                return PanelConverter(panel)
-            }
             if panel, ok := inputPanel.(*dashboardv2beta1.VizConfigKind); ok {
-                return VisualizationConverter(*panel)
+            	return VisualizationConverter(*panel)
             }
+            if panel, ok := inputPanel.(dashboardv2beta1.VizConfigKind); ok {
+            	return VisualizationConverter(panel)
+            }
+            {{- end }}
             
-            return VisualizationConverter(inputPanel.(dashboardv2beta1.VizConfigKind))
+            {{- if $hasV2 }}
+            {{- $dashboardv2 := importPkg "dashboardv2" }}
+            if panel, ok := inputPanel.(*dashboardv2.VizConfigKind); ok {
+            	return VisualizationV2Converter(*panel)
+            }
+            if panel, ok := inputPanel.(dashboardv2.VizConfigKind); ok {
+            	return VisualizationV2Converter(panel)
+            }
+            {{- end }}
+            
+            {{- if or $hasBeta $hasV2 }}
+            return "/* could not convert VizConfigKind */"
             {{- else }}
             return PanelConverter(inputPanel.(dashboard.Panel))
             {{- end }}

--- a/.cog/templates/go/overrides/schema_variant_panelcfg.tmpl
+++ b/.cog/templates/go/overrides/schema_variant_panelcfg.tmpl
@@ -63,6 +63,10 @@ func VariantConfig() {{ $variants }}.PanelcfgConfig {
 				return PanelConverter(*panel)
 			}
 			
+			if panel, ok := inputPanel.({{ $dashboard }}.Panel); ok {
+                return PanelConverter(panel)
+            }
+			
 			{{- $hasBeta := objectExists "dashboardv2beta1" "VizConfigKind" -}}
             {{- $hasV2 := objectExists "dashboardv2" "VizConfigKind" -}}
 			

--- a/.cog/templates/java/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl
+++ b/.cog/templates/java/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl
@@ -1,0 +1,54 @@
+{{- define "object_dashboardv2_DataQueryKind_custom_unmarshal" }}
+package {{ importPkg .Object.SelfRef.ReferredPkg }};
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import {{ importPkg "cog.variants.UnknownDataquery" }};
+import {{ importPkg "cog.variants.Dataquery" }};
+import {{ importPkg "cog.variants.Registry" }};
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+public class {{ .Object.Name | upperCamelCase }}Deserializer extends JsonDeserializer<{{ .Object.Name | upperCamelCase }}> {
+    
+    @Override
+    public {{ .Object.Name }} deserialize(JsonParser jp, DeserializationContext cxt) throws IOException {
+        ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+        JsonNode root = mapper.readTree(jp);
+        
+        {{ .Object.Name | upperCamelCase }} {{ .Object.Name | lowerCamelCase }} = new {{ .Object.Name }}();
+        {{- range $i, $field := .Object.Type.AsStruct.Fields }}
+        {{- if eq $field.Name "spec" }}
+        {{ continue }}
+        {{- else }}
+        {{ if gt $i 0 }}else {{ end }}if (root.has("{{ .Name }}")) {
+            {{ $.Object.Name | lowerCamelCase }}.{{ $field.Name | lowerCamelCase }} = mapper.convertValue(root.get("{{ .Name }}"), new TypeReference<>() {});
+        }
+        {{- end }}
+        {{- end }}
+        if ({{ .Object.Name | lowerCamelCase }}.group != null && !{{ .Object.Name | lowerCamelCase }}.group.trim().isEmpty()) {
+            Class<? extends Dataquery> clazz = Registry.getDataquery({{ .Object.Name | lowerCamelCase }}.group);
+            if (clazz != null) {
+                {{ $.Object.Name | lowerCamelCase }}.spec = mapper.treeToValue(root.get("spec"), clazz);
+            } else {
+                UnknownDataquery unknownDataquery = new UnknownDataquery();
+                Iterator<Map.Entry<String, JsonNode>> fieldsIterator = root.get("spec").fields();
+                while (fieldsIterator.hasNext()) {
+                  Map.Entry<String, JsonNode> field = fieldsIterator.next();
+                  unknownDataquery.genericFields.put(field.getKey(), mapper.treeToValue(field.getValue(), Object.class));
+                }
+                {{ $.Object.Name | lowerCamelCase }}.spec = unknownDataquery;
+            }
+        }
+        
+        return {{ .Object.Name | lowerCamelCase }};
+    }
+}
+{{- end }}

--- a/.cog/templates/java/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/java/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
@@ -1,0 +1,71 @@
+{{- define "object_dashboardv2_VizConfigKind_custom_unmarshal" }}
+package {{ importPkg .Object.SelfRef.ReferredPkg }};
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import {{ importPkg "cog.variants.PanelConfig" }};
+import {{ importPkg "cog.variants.Registry" }};
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+public class {{ .Object.Name | upperCamelCase }}Deserializer extends JsonDeserializer<{{ .Object.Name | upperCamelCase }}> {
+
+    @Override
+    public {{ .Object.Name }} deserialize(JsonParser jp, DeserializationContext cxt) throws IOException {
+        ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+        JsonNode root = mapper.readTree(jp);
+        
+        {{ $objName := .Object.Name | lowerCamelCase }}
+        {{ .Object.Name | upperCamelCase }} {{ $objName }} = new {{ .Object.Name }}();
+        {{- range $i, $field := .Object.Type.AsStruct.Fields }}
+        {{- if eq $field.Name "spec" }}
+            {{ template "object_dashboardv2_VizConfigKind_spec" (dict "Field" $field "ObjectName" $objName) }}
+        {{- else }}
+        {{ if gt $i 0 }}else {{ end }}if (root.has("{{ .Name }}")) {
+            {{ $.Object.Name | lowerCamelCase }}.{{ $field.Name | lowerCamelCase }} = mapper.convertValue(root.get("{{ .Name }}"), new TypeReference<>() {});
+        }
+        {{- end }}
+        {{- end }}
+        
+        return {{ $objName }};
+    }
+}
+{{- end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec" }}
+        {{ .Field.Type | formatType }} {{ .Field.Name }} = new {{ .Field.Type | formatType }}();
+        JsonNode specNode = root.get("{{ .Field.Name }}");
+        if (specNode != null && !specNode.isNull()) {
+            PanelConfig panelConfig = Registry.getPanel({{ .ObjectName }}.group);
+            if (panelConfig == null) {
+                throw new IllegalArgumentException("Unknown panel type: " + {{ .ObjectName }}.group);
+            }
+            {{- range $i, $field := (.Field.Type|resolveRefs).AsStruct.Fields }}
+            {{ if gt $i 0 }}else {{ end }}if (specNode.has("{{ $field.Name }}")) {
+                {{- if eq $field.Name "options" }}
+                    {{ $.Field.Name }}.options = mapper.treeToValue(root.get("options"), panelConfig.getOptionsClass());
+                {{- else if eq $field.Name "fieldConfig" }}
+                    {{ $field.Type | formatType }} fieldConfig = mapper.treeToValue(specNode.get("fieldConfig"), {{ $field.Type | formatType }}.class);
+                    if (fieldConfig != null && fieldConfig.defaults != null) {
+                        JsonNode customNode = specNode.get("fieldConfig").get("defaults").get("custom");
+                        Class<?> customClass = panelConfig.getFieldConfigClass();
+                        if (customNode != null && customClass != null) {
+                            fieldConfig.defaults.custom = mapper.treeToValue(customNode, panelConfig.getFieldConfigClass());
+                        }
+                        {{ $.Field.Name }}.fieldConfig = fieldConfig;
+                    }
+                {{- else }}
+                    {{ $.Field.Name }}.{{ $field.Name | lowerCamelCase }} = mapper.convertValue(root.get("{{ $field.Name }}"), new TypeReference<>() {});
+                {{- end }}
+            }
+            {{- end }}
+        }
+        {{ .ObjectName }}.{{ .Field.Name }} = {{ .Field.Name }};
+{{- end }}

--- a/.cog/templates/php/extra/src/Cog/DataqueryConfig.php
+++ b/.cog/templates/php/extra/src/Cog/DataqueryConfig.php
@@ -20,16 +20,7 @@ final class DataqueryConfig
     {{- $hasV2 := objectExists "dashboardv2" "DataQueryKind" -}}
     {{- if or $hasBeta $hasV2 }}
     /**
-     * @var (callable(
-     {{- if and $hasBeta $hasV2 }}
-        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind|
-        \Grafana\Foundation\Dashboardv2\DataQueryKind
-     {{- else if $hasBeta }}
-        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind
-     {{- else }}
-        \Grafana\Foundation\Dashboardv2\DataQueryKind
-     {{- end }}
-     ): string)|null
+     * @var (callable({{ if and $hasBeta $hasV2 }}\Grafana\Foundation\Dashboardv2beta1\DataQueryKind|\Grafana\Foundation\Dashboardv2\DataQueryKind{{ else if $hasBeta }}\Grafana\Foundation\Dashboardv2beta1\DataQueryKind{{ else }}\Grafana\Foundation\Dashboardv2\DataQueryKind{{ end }}): string)|null
      */
     public $convertv2;
     {{- end }}
@@ -38,16 +29,7 @@ final class DataqueryConfig
      * @param callable(array<string, mixed>): Dataquery $fromArray
      * @param (callable(Dataquery): string)|null $convert
     {{- if or $hasBeta $hasV2 }}
-     * @param (callable(
-    {{- if and $hasBeta $hasV2 }}
-        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind|
-        \Grafana\Foundation\Dashboardv2\DataQueryKind
-    {{- else if $hasBeta }}
-        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind
-    {{- else }}
-        \Grafana\Foundation\Dashboardv2\DataQueryKind
-    {{- end }}
-    ): string)|null $convertv2
+     * @param (callable({{ if and $hasBeta $hasV2 }}\Grafana\Foundation\Dashboardv2beta1\DataQueryKind|\Grafana\Foundation\Dashboardv2\DataQueryKind{{ else if $hasBeta }}\Grafana\Foundation\Dashboardv2beta1\DataQueryKind{{ else }}\Grafana\Foundation\Dashboardv2\DataQueryKind{{ end }}): string)|null $convertv2
     {{- end }}
      */
     public function __construct(string $identifier, callable $fromArray, ?callable $convert = null{{ if or (objectExists "dashboardv2beta1" "DataQueryKind") (objectExists "dashboardv2" "DataQueryKind") }}, ?callable $convertv2 = null{{ end }})

--- a/.cog/templates/php/extra/src/Cog/DataqueryConfig.php
+++ b/.cog/templates/php/extra/src/Cog/DataqueryConfig.php
@@ -16,9 +16,20 @@ final class DataqueryConfig
      */
     public $convert;
     
-    {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
+    {{- $hasBeta := objectExists "dashboardv2beta1" "DataQueryKind" -}}
+    {{- $hasV2 := objectExists "dashboardv2" "DataQueryKind" -}}
+    {{- if or $hasBeta $hasV2 }}
     /**
-     * @var (callable(\Grafana\Foundation\Dashboardv2beta1\DataQueryKind): string)|null
+     * @var (callable(
+     {{- if and $hasBeta $hasV2 }}
+        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind|
+        \Grafana\Foundation\Dashboardv2\DataQueryKind
+     {{- else if $hasBeta }}
+        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind
+     {{- else }}
+        \Grafana\Foundation\Dashboardv2\DataQueryKind
+     {{- end }}
+     ): string)|null
      */
     public $convertv2;
     {{- end }}
@@ -26,16 +37,25 @@ final class DataqueryConfig
     /**
      * @param callable(array<string, mixed>): Dataquery $fromArray
      * @param (callable(Dataquery): string)|null $convert
-     {{- if objectExists "dashboardv2beta1" "DataQueryKind" }} 
-     * @param (callable(\Grafana\Foundation\Dashboardv2beta1\DataQueryKind): string)|null $convertv2 
-     {{- end }}
+    {{- if or $hasBeta $hasV2 }}
+     * @param (callable(
+    {{- if and $hasBeta $hasV2 }}
+        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind|
+        \Grafana\Foundation\Dashboardv2\DataQueryKind
+    {{- else if $hasBeta }}
+        \Grafana\Foundation\Dashboardv2beta1\DataQueryKind
+    {{- else }}
+        \Grafana\Foundation\Dashboardv2\DataQueryKind
+    {{- end }}
+    ): string)|null $convertv2
+    {{- end }}
      */
-    public function __construct(string $identifier, callable $fromArray, ?callable $convert = null{{ if objectExists "dashboardv2beta1" "DataQueryKind" }}, ?callable $convertv2 = null{{ end }})
+    public function __construct(string $identifier, callable $fromArray, ?callable $convert = null{{ if or (objectExists "dashboardv2beta1" "DataQueryKind") (objectExists "dashboardv2" "DataQueryKind") }}, ?callable $convertv2 = null{{ end }})
     {
         $this->identifier = $identifier;
         $this->fromArray = $fromArray;
         $this->convert = $convert;
-        {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
+        {{- if or (objectExists "dashboardv2beta1" "DataQueryKind") (objectExists "dashboardv2" "DataQueryKind") }}
         $this->convertv2 = $convertv2;
         {{- end }}
     }

--- a/.cog/templates/php/extra/src/Cog/PanelcfgConfig.php
+++ b/.cog/templates/php/extra/src/Cog/PanelcfgConfig.php
@@ -2,7 +2,7 @@
 
 namespace {{ .Data.NamespaceRoot }}\Cog;
 {{- $convertReturn := "\\Grafana\\Foundation\\Dashboard\\Panel" -}}
-{{- if (objectExists "dashboardv2beta1" "VizConfigKind") -}}
+{{- if or (objectExists "dashboardv2beta1" "VizConfigKind") (objectExists "dashboardv2" "VizConfigKind") -}}
   {{- $convertReturn = "mixed" -}}
 {{- end -}}
 

--- a/.cog/templates/php/extra/src/Cog/Runtime.php
+++ b/.cog/templates/php/extra/src/Cog/Runtime.php
@@ -97,7 +97,7 @@ final class Runtime
     }
 
     {{ $panelArgument := "\\Grafana\\Foundation\\Dashboard\\Panel" }}
-    {{- if objectExists "dashboardv2beta1" "VizConfigKind" }}
+    {{- if or (objectExists "dashboardv2beta1" "VizConfigKind") (objectExists "dashboardv2" "VizConfigKind") }}
     {{- $panelArgument = "mixed" }}
     {{- end }}
 
@@ -133,8 +133,17 @@ final class Runtime
         return $convert($dataquery);
     }
 
-    {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
-    public function convertDataQueryKindToCode(\Grafana\Foundation\Dashboardv2beta1\DataQueryKind $dataquery, string $group): string 
+    {{- $typeHint := "" -}}
+    {{- if objectExists "dashboardv2beta1" "DataQueryKind" -}}
+      {{- $typeHint = "\\Grafana\\Foundation\\Dashboardv2beta1\\DataQueryKind" -}}
+    {{- end -}}
+    {{- if objectExists "dashboardv2" "DataQueryKind" -}}
+      {{- if ne $typeHint "" -}}{{- $typeHint = print $typeHint "|" -}}{{- end -}}
+      {{- $typeHint = print $typeHint "\\Grafana\\Foundation\\Dashboardv2\\DataQueryKind" -}}
+    {{- end -}}
+
+    {{- if ne $typeHint "" }}
+    public function convertDataQueryKindToCode({{ $typeHint }} $dataquery, string $group): string
     {
     	if (!isset($this->dataqueryVariants[$group])) {
             return '/* could not convert DataQueryKind to PHP */';

--- a/.cog/templates/php/extra/src/Cog/Runtime.php
+++ b/.cog/templates/php/extra/src/Cog/Runtime.php
@@ -68,7 +68,7 @@ final class Runtime
     public function dataqueryFromArray(array $data, string $dataqueryTypeHint): Dataquery
     {
         // Dataqueries might reference the datasource to use, and its type. Let's use that.
-        if (empty($dataqueryTypeHint) && !empty($data['datasource']) && !empty($data['datasource']['type'])) {
+        if (empty($dataqueryTypeHint) && !empty($data['datasource']) && is_string($data['datasource']['type']) && $data['datasource']['type'] !== '') {
             $dataqueryTypeHint = $data['datasource']['type'];
         }
 

--- a/.cog/templates/php/overrides/dynamic_files.tmpl
+++ b/.cog/templates/php/overrides/dynamic_files.tmpl
@@ -95,19 +95,24 @@ final class VariantConfig
         );
     }
     
-    {{- if objectExists "dashboardv2beta1" "VizConfigKind" }}
     public static function convert(mixed $input): string
     {
         if ($input instanceof {{ fullNamespaceRef "Dashboard\\Panel" }}) {
             return PanelConverter::convert($input);
         }
     
+        {{- if objectExists "dashboardv2beta1" "VizConfigKind" }}
         if ($input instanceof {{ fullNamespaceRef "Dashboardv2beta1\\VizConfigKind" }}) {
             return VisualizationConverter::convert($input);
         }
+        {{- end }}
+        {{- if objectExists "dashboardv2" "VizConfigKind" }}
+        if ($input instanceof {{ fullNamespaceRef "Dashboardv2\\VizConfigKind" }}) {
+            return VisualizationConverter::convert($input);
+        }
+        {{- end }}
     
         return '/* could not convert panel */';
     }
-    {{- end }}
 }
 {{ end }}

--- a/.cog/templates/php/overrides/dynamic_files.tmpl
+++ b/.cog/templates/php/overrides/dynamic_files.tmpl
@@ -108,7 +108,7 @@ final class VariantConfig
         {{- end }}
         {{- if objectExists "dashboardv2" "VizConfigKind" }}
         if ($input instanceof {{ fullNamespaceRef "Dashboardv2\\VizConfigKind" }}) {
-            return VisualizationConverter::convert($input);
+            return VisualizationV2Converter::convert($input);
         }
         {{- end }}
     

--- a/.cog/templates/php/overrides/dynamic_files.tmpl
+++ b/.cog/templates/php/overrides/dynamic_files.tmpl
@@ -19,6 +19,8 @@
 {{- $convertv2 := "null" -}}
 {{- $fromArray := "null" -}}
 {{- $entryPointNotFound := not (schemaHasObject .Schema .Schema.EntryPoint) -}}
+{{- $hasBeta := objectExists "dashboardv2beta1" "DataQueryKind" -}}
+{{- $hasV2 := objectExists "dashboardv2" "DataQueryKind" -}}
 
 {{- if and ($entryPointNotFound) (resolvesToDisjunction .Schema.EntryPointType)  -}}
 {{- $fromArray = unmarshalDisjunctionFunc .Schema.EntryPointType -}}
@@ -31,11 +33,15 @@
     {{- if .Schema.EntryPointType|resolvesToDisjunction -}}
     {{- $convert = convertDisjunctionFunc .Schema.EntryPointType -}}
     {{- end -}}
-    
-    {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
-    {{- $convertv2 = print "[QueryConverter::class, 'convert']" -}}
-    {{- end }}
-    
+
+    {{- if and $hasBeta $hasV2 -}}
+    {{- $convertv2 = "[self::class, 'convertV2']" -}}
+    {{- else if $hasBeta -}}
+    {{- $convertv2 = "[QueryConverter::class, 'convert']" -}}
+    {{- else if $hasV2 -}}
+    {{- $convertv2 = "[QueryV2Converter::class, 'convert']" -}}
+    {{- end -}}
+
 {{- end -}}
 <?php
 
@@ -49,11 +55,22 @@ final class VariantConfig
             identifier: '{{ .Schema.Metadata.Identifier }}',
             fromArray: {{ $fromArray }},
             convert: {{ $convert }},
-            {{- if objectExists "dashboardv2beta1" "DataQueryKind" }}
+            {{- if or $hasBeta $hasV2 }}
             convertv2: {{ $convertv2 }},
             {{- end }}
         );
     }
+
+    {{- if and $hasBeta $hasV2 }}
+
+    public static function convertV2({{ fullNamespaceRef "Dashboardv2\\DataQueryKind" }}|{{ fullNamespaceRef "Dashboardv2beta1\\DataQueryKind" }} $input): string
+    {
+        if ($input instanceof {{ fullNamespaceRef "Dashboardv2\\DataQueryKind" }}) {
+            return QueryV2Converter::convert($input);
+        }
+        return QueryConverter::convert($input);
+    }
+    {{- end }}
 
 }
 {{ end }}

--- a/.cog/templates/php/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl.tmpl
+++ b/.cog/templates/php/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl.tmpl
@@ -1,0 +1,29 @@
+{{- define "object_dashboardv2_DataQueryKind_custom_unmarshal" }}
+/**
+ * @param array<string, mixed> $inputData
+ */
+public static function fromArray(array $inputData): self
+{
+    /** @var {{ typeShape .Object.Type }} $inputData */
+    $data = $inputData;
+    return new self(
+        {{- range $field := .Object.Type.Struct.Fields }} 
+        {{ if eq $field.Name "spec" -}}
+        {{ $field.Name }}: {{ template "dashboardv2_DataQueryKind_spec_unmarshal" }}
+        {{- else if or $field.Type.IsConcreteScalar $field.Type.IsConstantRef }}
+        {{ continue }}
+        {{- else -}}
+        {{ $field.Name }}: {{ unmarshalForType $field.Type (print "$data[\"" $field.Name "\"]") }}
+        {{- end -}},
+        {{- end }}
+   );
+}
+{{- end }}
+
+{{- define "dashboardv2_DataQueryKind_spec_unmarshal" -}}
+isset($data['spec']) ? (function($input) {
+    /** @var array<string, mixed> $spec */
+    $spec = $input['spec'];
+    return \Grafana\Foundation\Cog\Runtime::get()->dataqueryFromArray($spec, $input['group'] ?? '');
+})($data) : null
+{{- end }}

--- a/.cog/templates/php/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/php/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
@@ -1,0 +1,92 @@
+{{- define "object_dashboardv2_VizConfigKind_custom_unmarshal" }}
+/**
+ * @param array<string, mixed> $inputData
+ */
+public static function fromArray(array $inputData): self
+{
+    /** @var {{ typeShape .Object.Type }} $inputData */
+    $data = $inputData;
+    return new self(
+        {{- range $field := .Object.Type.Struct.Fields }}
+        {{- if eq $field.Name "spec" -}}
+        {{ $field.Name }}: {{ template "object_dashboardv2_VizConfigKind_spec_unmarshal" (dict "Field" $field) }}
+        {{- else if or $field.Type.IsConcreteScalar $field.Type.IsConstantRef }}
+        {{ continue }}
+        {{- else -}}
+        {{ $field.Name }}: {{ unmarshalForType $field.Type (print "$data[\"" $field.Name "\"]") }}
+        {{- end -}},
+        {{- end }}
+   );
+}
+{{- end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_unmarshal" -}}
+isset($data['spec']) ? (function($input) {
+    /** @var {{ typeShape (.Field.Type|resolveRefs) }} $spec */
+    $spec = $input['spec'];
+    /** @var string $group */
+    $group = $input['group'] ?? '';
+    return new VizConfigSpec(
+        {{- range $field := (.Field.Type|resolveRefs).Struct.Fields }}
+        {{ $field.Name }}: {{ if eq $field.Name "options" -}}
+            {{ template "object_dashboardv2_VizConfigKind_spec_options_unmarshal" }}
+        {{- else if eq $field.Name "fieldConfig" -}}
+            {{ template "object_dashboardv2_VizConfigKind_spec_fieldConfig_unmarshal" }}
+        {{- else if $field.Type.IsConcreteScalar }}
+        {{ continue}}
+        {{- else -}}
+        {{ unmarshalForType $field.Type (print "$spec[\"" $field.Name "\"]") }}
+        {{- end -}},
+        {{- end }}
+   );
+})($data) : null
+{{- end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_fieldConfig_unmarshal" -}}
+isset($spec["fieldConfig"]) ? (function(string $panelType, $panel) {
+    /** @var array<string, mixed> $fieldConfigData */
+    $fieldConfigData = $panel["fieldConfig"];
+    $fieldConfigSource = FieldConfigSource::fromArray($fieldConfigData);
+
+    if (!\Grafana\Foundation\Cog\Runtime::get()->panelcfgVariantExists($panelType)) {
+        return $fieldConfigSource;
+    }
+
+    $config = \Grafana\Foundation\Cog\Runtime::get()->panelcfgVariantConfig($panelType);
+    if ($config->fieldConfigFromArray === null) {
+        return $fieldConfigSource;
+    }
+
+    if (!isset($fieldConfigData["defaults"])) {
+        return $fieldConfigSource;
+    }
+
+    /** @var array{custom?: array<string, mixed>} $defaults */
+    $defaults = $fieldConfigData["defaults"];
+    if (!isset($defaults["custom"])) {
+        return $fieldConfigSource;
+    }
+
+    $fieldConfigSource->defaults->custom = ($config->fieldConfigFromArray)($defaults["custom"]);
+
+    return $fieldConfigSource;
+})($group, $spec) : null
+{{- end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_options_unmarshal" -}}
+isset($spec["options"]) ? (function(string $panelType, $panel) {
+    /** @var array<string, mixed> $options */
+    $options = $panel["options"];
+
+    if (!\Grafana\Foundation\Cog\Runtime::get()->panelcfgVariantExists($panelType)) {
+        return $options;
+    }
+
+    $config = \Grafana\Foundation\Cog\Runtime::get()->panelcfgVariantConfig($panelType);
+    if ($config->optionsFromArray === null) {
+        return $options;
+    }
+
+    return ($config->optionsFromArray)($options);
+})($group, $spec) : null
+{{- end }}

--- a/.cog/templates/python/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl.tmpl
+++ b/.cog/templates/python/overrides/object_dashboardv2_DataQueryKind_custom_unmarshal.tmpl.tmpl
@@ -1,0 +1,22 @@
+{{- define "object_dashboardv2_DataQueryKind_custom_unmarshal" }}
+@classmethod
+def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+    args: dict[str, typing.Any] = {}
+{{ range $field := .Object.Type.Struct.Fields }}
+    {{- if eq $field.Name "spec" }}
+    if "{{ $field.Name }}" in data:
+        args["{{ $field.Name }}"] = {{ template "dashboardv2_DataQueryKind_spec_unmarshal" (dict "Field" $field) }}
+    {{- else if $field.Type.IsConcreteScalar }}
+        {{ continue}}
+    {{- else }}
+    if "{{ $field.Name }}" in data:
+        args["{{ $field.Name }}"] = data["{{ $field.Name }}"]
+{{ end -}}
+{{ end }}
+    return cls(**args)
+{{- end }}
+
+{{- define "dashboardv2_DataQueryKind_spec_unmarshal" -}}
+{{- $cogruntime := importModule "cogruntime" "..cog" "runtime" -}}
+{{ $cogruntime }}.dataquery_from_json(data["{{ .Field.Name }}"],  data["group"])
+{{- end }}

--- a/.cog/templates/python/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
+++ b/.cog/templates/python/overrides/object_dashboardv2_VizConfigKind_custom_unmarshal.tmpl
@@ -1,0 +1,52 @@
+{{- define "object_dashboardv2_VizConfigKind_custom_unmarshal" }}
+@classmethod
+def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+    args: dict[str, typing.Any] = {}
+    defaults: dict[str, typing.Any] = {}
+    custom: dict[str, typing.Any] = {}
+    try:
+        defaults = data["spec"]["fieldConfig"]["defaults"]
+        custom = defaults.get("custom", {})
+    except KeyError:
+        pass
+
+{{ range $field := .Object.Type.Struct.Fields }}
+    {{- if eq $field.Name "spec" }}
+    if "{{ $field.Name }}" in data:
+        args["{{ $field.Name|formatIdentifier }}"] = {{ template "object_dashboardv2_VizConfigKind_spec_unmarshal" (dict "Field" $field) }}
+    {{- else if $field.Type.IsConcreteScalar }}
+        {{ continue}}
+    {{- else }}
+    if "{{ $field.Name }}" in data:
+        args["{{ $field.Name|formatIdentifier }}"] = {{ unmarshalForType $field.Type (print "data[\"" $field.Name "\"]") $field.Name }}
+{{ end -}}
+{{ end }}
+    return cls(**args)
+{{- end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_unmarshal" -}}
+VizConfigSpec(
+{{- range $field := (.Field.Type|resolveRefs).Struct.Fields }}
+{{- $input := print "data[\"spec\"][\"" $field.Name "\"]" -}}
+    {{ $field.Name|formatIdentifier }}=
+{{- if eq $field.Name "options" -}}
+    {{ template "object_dashboardv2_VizConfigKind_spec_options_unmarshal" }}
+{{- else if eq $field.Name "fieldConfig" -}}
+    {{ template "object_dashboardv2_VizConfigKind_spec_fieldConfig_unmarshal" }}
+{{- else -}}
+    {{ (unmarshalForType $field.Type $input $field.Name).DecodingCall }}
+{{- end }} if {{ $input }} is not None else {{ defaultForType $field.Type}},
+{{- end -}}
+)
+{{- end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_fieldConfig_unmarshal" -}}
+{{- $cogruntime := importModule "cogruntime" "..cog" "runtime" -}}
+FieldConfigSource.from_json({**data["spec"]["fieldConfig"], **{"defaults": {**defaults, **{"custom": {{ $cogruntime }}.panelcfg_field_config_from_json(custom, data["group"])}}}})
+{{- end }}
+
+{{- define "object_dashboardv2_VizConfigKind_spec_options_unmarshal" -}}
+{{- $input := print "data[\"spec\"][\"options\"]" -}}
+{{- $cogruntime := importModule "cogruntime" "..cog" "runtime" -}}
+{{ $cogruntime }}.panelcfg_options_from_json({{ $input }}, data["kind"])
+{{- end }}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 /.cog/resources/playlistv0alpha1/ @grafana/grafana-app-platform-squad
 /.cog/resources/preferencesv1alpha1/ @grafana/grafana-app-platform-squad
 /.cog/resources/starsv1alpha1/ @grafana/grafana-app-platform-squad
+/.cog/resources/dashboardv2/ @grafana/dashboards-squad

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COG_VERSION = v0.1.9
+COG_VERSION = v0.1.10
 COG_DIR     = $(shell go env GOPATH)/bin/cog-$(COG_VERSION)
 COG_BIN     = $(COG_DIR)/cli
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COG_VERSION = v0.1.10
+COG_VERSION = v0.1.11
 COG_DIR     = $(shell go env GOPATH)/bin/cog-$(COG_VERSION)
 COG_BIN     = $(COG_DIR)/cli
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COG_VERSION = v0.1.4
+COG_VERSION = v0.1.9
 COG_DIR     = $(shell go env GOPATH)/bin/cog-$(COG_VERSION)
 COG_BIN     = $(COG_DIR)/cli
 


### PR DESCRIPTION
Adds `dashboardv2` (stable v2) as a new codegen resource and ports the builder transform ergonomics from `dashboardv2beta1` into the new dashboardv2 unit.

