### PR TITLE
Update Tempo entrypoint name

### DIFF
--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -33,6 +33,7 @@ inputs:
         - '%__config_dir%/resources/loki/schema.transforms.yaml'
         - '%__config_dir%/resources/piechart/schema.transforms.yaml'
         - '%__config_dir%/resources/statetimeline/schema.transforms.yaml'
+        - '%__config_dir%/resources/tempo/schema.transforms.yaml'
         - '%__config_dir%/resources/timeseries/schema.transforms.yaml'
   - openapi:
       url: 'https://raw.githubusercontent.com/grafana/grafana/v11.6.0/public/openapi3.json'

--- a/.cog/resources/tempo/schema.transforms.yaml
+++ b/.cog/resources/tempo/schema.transforms.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/compiler_passes.json
+
+# Java conflicts TempoQuery composable name...
+passes:
+  - rename_object:
+      from: tempo.TempoQuery
+      to: Dataquery
+  - schema_set_entry_point:
+      package: tempo
+      entry_point: Dataquery


### PR DESCRIPTION
Java compose file names conflicts when we have entrypoints with the same name as package + Query. It changes the name as Dataquery, as we have in other datasources.

We need it for: https://github.com/grafana/grafana-foundation-sdk/pull/1191