### PR TITLE
Expr: Update schema URL

### DIFF
--- a/.cog/resources/expr/config.yaml
+++ b/.cog/resources/expr/config.yaml
@@ -2,7 +2,7 @@
 
 inputs:
   - jsonschema:
-      url: 'https://raw.githubusercontent.com/grafana/grafana/main/pkg/expr/query.request.schema.json'
+      url: 'https://raw.githubusercontent.com/grafana/grafana/refs/heads/release-13.0.2/pkg/expr/query.request.schema.json'
       package: expr
       metadata:
         kind: composable


### PR DESCRIPTION
Expr schema was deleted from the main branch of Grafana. It's updated with a fixed branch to continuing using it until we have a new alternative.