### PR TITLE
Tempo: Fix datasource field name

### DIFF
--- a/.cog/resources/dataqueries.schema.transforms.yaml
+++ b/.cog/resources/dataqueries.schema.transforms.yaml
@@ -55,5 +55,5 @@ passes:
       field: parca.Dataquery.datasource
       as: *common_datasourceRef
   - retype_field:
-      field: tempo.TempoQuery.datasource
+      field: tempo.Dataquery.datasource
       as: *common_datasourceRef


### PR DESCRIPTION
After update Tempo [here](https://github.com/grafana/grafana-foundation-sdk/pull/1192), we missed to update the new name for datasource ref.