### PR TITLE
Rename api version to avoid duplicate docs

### DIFF
--- a/.cog/resources/dashboardv2beta1/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2beta1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: dashboardv2beta1.DashboardV2Beta1
+      object: dashboardv2beta1.DashboardApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "dashboard.grafana.app/v2beta1" }

--- a/.cog/resources/folderv1beta1/schema.transforms.yaml
+++ b/.cog/resources/folderv1beta1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: folderv1beta1.FolderV1Beta1
+      object: folderv1beta1.FolderApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "folder.grafana.app/v1beta1" }

--- a/.cog/resources/playlistv0alpha1/schema.transforms.yaml
+++ b/.cog/resources/playlistv0alpha1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: playlistv0alpha1.PlaylistV0Alpha1
+      object: playlistv0alpha1.PlaylistApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "playlist.grafana.app/playlistv0alpha1" }

--- a/.cog/resources/preferencesv1alpha1/schema.transforms.yaml
+++ b/.cog/resources/preferencesv1alpha1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: preferencesv1alpha1.PreferencesV1Alpha1
+      object: preferencesv1alpha1.PreferencesApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "preferences.grafana.app/v1alpha1" }


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana-foundation-sdk/issues/1207

The current constants added have the same name than the main object, producing duplicated documentation. 
