### PR TITLE
Dashboard: Return empty struct instead of null when no visualization options

### DIFF
--- a/.cog/resources/dashboardv2/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2/schema.transforms.yaml
@@ -39,6 +39,10 @@ passes:
         scalar: { scalar_kind: any }
         nullable: true
 
+  - fields_set_default:
+      defaults:
+        dashboardv2.VizConfigSpec.options: {}
+
   - retype_field:
       field: dashboardv2.FieldConfig.custom
       as:

--- a/.cog/resources/dashboardv2beta1/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2beta1/schema.transforms.yaml
@@ -31,6 +31,10 @@ passes:
         scalar: { scalar_kind: any }
         nullable: true
 
+  - fields_set_default:
+      defaults:
+        dashboardv2beta1.VizConfigSpec.options: {}
+
   - retype_field:
       field: dashboardv2beta1.FieldConfig.custom
       as:
@@ -60,7 +64,7 @@ passes:
       from: dashboardv2beta1.DashboardSpec
       to: Dashboard
 
-  # To get rid of the default value (each panel query needs a unique refId, and
+  # To get rid of the default value (each panel query needs a unique refId, and
   # an empty value as default makes it easier to identify that a unique refId
   # needs to be computed)
   - retype_field:

--- a/.cog/resources/dashboardv2beta1/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2beta1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: dashboardv2beta1.DashboardV2Beta1
+      object: dashboardv2beta1.DashboardApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "dashboard.grafana.app/v2beta1" }

--- a/.cog/resources/folderv1beta1/schema.transforms.yaml
+++ b/.cog/resources/folderv1beta1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: folderv1beta1.FolderV1Beta1
+      object: folderv1beta1.FolderApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "folder.grafana.app/v1beta1" }

--- a/.cog/resources/playlistv0alpha1/schema.transforms.yaml
+++ b/.cog/resources/playlistv0alpha1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: playlistv0alpha1.PlaylistV0Alpha1
+      object: playlistv0alpha1.PlaylistApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "playlist.grafana.app/playlistv0alpha1" }

--- a/.cog/resources/preferencesv1alpha1/schema.transforms.yaml
+++ b/.cog/resources/preferencesv1alpha1/schema.transforms.yaml
@@ -3,7 +3,7 @@
 passes:
   # Add a few useful constants
   - add_object:
-      object: preferencesv1alpha1.PreferencesV1Alpha1
+      object: preferencesv1alpha1.PreferencesApiVersion
       as:
         kind: scalar
         scalar: { scalar_kind: string, value: "preferences.grafana.app/v1alpha1" }


### PR DESCRIPTION
Depends of: https://github.com/grafana/cog/pull/1099
Fixes: https://github.com/grafana/grafana-foundation-sdk/issues/1203

It sets empty slice as default when we don't set it in panels since options is mandatory.