### PR TITLE
Dashboards: Set empty slice as default in options

### DIFF
--- a/.cog/resources/dashboardv2/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2/schema.transforms.yaml
@@ -39,6 +39,10 @@ passes:
         scalar: { scalar_kind: any }
         nullable: true
 
+  - fields_set_default:
+      defaults:
+        dashboardv2.VizConfigSpec.options: {}
+
   - retype_field:
       field: dashboardv2.FieldConfig.custom
       as:

--- a/.cog/resources/dashboardv2beta1/schema.transforms.yaml
+++ b/.cog/resources/dashboardv2beta1/schema.transforms.yaml
@@ -31,6 +31,10 @@ passes:
         scalar: { scalar_kind: any }
         nullable: true
 
+  - fields_set_default:
+      defaults:
+        dashboardv2beta1.VizConfigSpec.options: {}
+
   - retype_field:
       field: dashboardv2beta1.FieldConfig.custom
       as:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COG_VERSION = v0.1.11
+COG_VERSION = v0.1.12
 COG_DIR     = $(shell go env GOPATH)/bin/cog-$(COG_VERSION)
 COG_BIN     = $(COG_DIR)/cli
 


### PR DESCRIPTION
Contributes to: https://github.com/grafana/grafana-foundation-sdk/issues/1220
Depends of: https://github.com/grafana/cog/pull/1099 and https://github.com/grafana/cog/pull/1101
Fixes: https://github.com/grafana/grafana-foundation-sdk/issues/1203

It sets empty slice as default when we don't set it in panels since options is mandatory.