### PR TITLE
Java: Set Panel and VizConfigKind as generic builders for Java

### DIFF
--- a/.cog/resources/dashboard/builder-transforms/dashboard.java.yaml
+++ b/.cog/resources/dashboard/builder-transforms/dashboard.java.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [java]
+
+package: dashboard
+
+builders:
+  - set_as_generic:
+      by_object: Panel

--- a/.cog/resources/dashboardv2/builder-transforms/dashboard.java.yaml
+++ b/.cog/resources/dashboardv2/builder-transforms/dashboard.java.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [java]
+
+package: dashboardv2
+
+builders:
+  - set_as_generic:
+      by_object: VizConfigKind

--- a/.cog/resources/dashboardv2beta1/builder-transforms/dashboard.java.yaml
+++ b/.cog/resources/dashboardv2beta1/builder-transforms/dashboard.java.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json
+
+languages: [java]
+
+package: dashboardv2beta1
+
+builders:
+  - set_as_generic:
+      by_object: VizConfigKind

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COG_VERSION = v0.1.11
+COG_VERSION = v0.1.13
 COG_DIR     = $(shell go env GOPATH)/bin/cog-$(COG_VERSION)
 COG_BIN     = $(COG_DIR)/cli
 


### PR DESCRIPTION
It sets visualization builders as generic to be able to extend them for third party panels.

~Note: It needs a new cog release.~