### PR TITLE
Add missing Annotation fields

### DIFF
--- a/.cog/resources/dashboard/schema.transforms.yaml
+++ b/.cog/resources/dashboard/schema.transforms.yaml
@@ -80,6 +80,45 @@ passes:
 
   # Add a few missing fields.
   # This is meant to be removed once the schema is updated.
+  - add_object:
+      object: dashboard.AnnotationEventFieldSource
+      comments:
+        - Annotation event field source. Defines how to obtain the value for an annotation event field.
+        - '- "field": Find the value with a matching key (default)'
+        - '- "text": Write a constant string into the value'
+        - '- "skip": Do not include the field'
+      as:
+        kind: enum
+        enum:
+          values:
+            - { type: { kind: scalar, scalar: { scalar_kind: string } }, name: field, value: field }
+            - { type: { kind: scalar, scalar: { scalar_kind: string } }, name: text, value: text }
+            - { type: { kind: scalar, scalar: { scalar_kind: string } }, name: skip, value: skip }
+
+  - add_object:
+      object: dashboard.AnnotationEventFieldMapping
+      comments:
+        - Annotation event field mapping. Defines how to map a data frame field to an annotation event field.
+      as:
+        kind: struct
+        struct:
+          fields:
+            - name: source
+              comments: [ 'Source type for the field value.' ]
+              type:
+                kind: ref
+                ref: { referred_pkg: dashboard, referred_type: AnnotationEventFieldSource }
+            - name: value
+              comments: [ 'Constant value to use when source is "text".' ]
+              type:
+                kind: scalar
+                scalar: { scalar_kind: string }
+            - name: regex
+              comments: [ 'Regular expression to apply to the field value.' ]
+              type:
+                kind: scalar
+                scalar: { scalar_kind: string }
+
   - add_fields:
       to: dashboard.AnnotationQuery
       fields:
@@ -87,7 +126,31 @@ passes:
           type:
             kind: scalar
             scalar: { scalar_kind: string }
-            
+        - name: textFormat
+          comments:
+            - Format for Prometheus annotation text. Label values can be interpolated with templates like {{instance}}.
+          type:
+            kind: scalar
+            scalar: { scalar_kind: string }
+        - name: useValueForTime
+          comments:
+            - Use the Prometheus series value as the annotation timestamp.
+          type:
+            kind: scalar
+            scalar: { scalar_kind: bool }
+        - name: mappings
+          comments:
+            - Mappings define how to convert data frame fields to annotation event fields.
+          type:
+            kind: map
+            map:
+              indextype:
+                kind: scalar
+                scalar: { scalar_kind: string }
+              valuetype:
+                kind: ref
+                ref: { referred_pkg: dashboard, referred_type: AnnotationEventFieldMapping }
+             
   - add_fields:
       to: dashboard.FieldConfig
       fields:

--- a/.cog/resources/dashboard/schema.transforms.yaml
+++ b/.cog/resources/dashboard/schema.transforms.yaml
@@ -132,6 +132,24 @@ passes:
           type:
             kind: scalar
             scalar: { scalar_kind: string }
+        - name: titleFormat
+          comments:
+            - Format for Prometheus and Loki annotation titles. Label values can be interpolated with templates like {{instance}}.
+          type:
+            kind: scalar
+            scalar: { scalar_kind: string }
+        - name: tagKeys
+          comments:
+            - Comma-separated label keys used as annotation tags.
+          type:
+            kind: scalar
+            scalar: { scalar_kind: string }
+        - name: step
+          comments:
+            - Legacy Prometheus annotation query step interval.
+          type:
+            kind: scalar
+            scalar: { scalar_kind: string }
         - name: useValueForTime
           comments:
             - Use the Prometheus series value as the annotation timestamp.


### PR DESCRIPTION
resolves: #282 

This adds the missing annotation query fields to the legacy dashboard. I tried to dig through the repo to find out where this needs to best be applied. I understand that the schema itself should probably be adapted, if this isn't the correct approach then please let me know where this best can be applied.

This is currently blocking us to evaluate the grafana-foundation-sdk as we heavy rely on annotations in our dashboards.