### PR TITLE
Fix azuremonitor package generation

### DIFF
--- a/.cog/config.yaml
+++ b/.cog/config.yaml
@@ -24,6 +24,7 @@ inputs:
         - dashboard
       transformations:
         - '%__config_dir%/resources/kind_registry.schema.transforms.yaml'
+        - '%__config_dir%/resources/azuremonitor/schema.transforms.yaml'
         - '%__config_dir%/resources/candlestick/schema.transforms.yaml'
         - '%__config_dir%/resources/cloudwatch/schema.transforms.yaml'
         - '%__config_dir%/resources/common/schema.transforms.yaml'

--- a/.cog/resources/azuremonitor/schema.transforms.yaml
+++ b/.cog/resources/azuremonitor/schema.transforms.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/compiler_passes.json
+
+passes:
+  - trim_object_name_prefix:
+      prefix: Azure

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COG_VERSION = v0.1.11
+COG_VERSION = v0.1.14
 COG_DIR     = $(shell go env GOPATH)/bin/cog-$(COG_VERSION)
 COG_BIN     = $(COG_DIR)/cli
 


### PR DESCRIPTION
This PR bumps cog to v0.1.14 to benefit from case-insensitive duplicated files checks and generates cleaner object names for azuremonitor package (which fixes https://github.com/grafana/grafana-foundation-sdk/issues/1249)