### PR TITLE
Restore GitHub app for CI/release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,11 +39,26 @@ jobs:
           enable-cache: 'true'
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
+      - name: Get secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=github_app:app-id
+            GITHUB_APP_PRIVATE_KEY=github_app:private-key
+
+      - name: Generate github private token
+        id: generate_github_token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Prepare a release
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${{ env.GENERATED_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
 
           devbox run make prepare-release
         env:
@@ -53,12 +68,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # to be used by `gh`
           DRY_RUN: 'no'
           SKIP_VALIDATION: 'no'
+          GENERATED_GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Release
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${{ env.GENERATED_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
 
           devbox run ./scripts/release.sh
         env:
@@ -66,3 +82,4 @@ jobs:
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
           DRY_RUN: 'no'
+          GENERATED_GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,42 +39,32 @@ jobs:
           enable-cache: 'true'
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
-      - name: Get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+      - name: Generate github token
+        id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.3.1
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=github_app:app-id
-            GITHUB_APP_PRIVATE_KEY=github_app:private-key
-
-      - name: Generate github private token
-        id: generate_github_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: foundation-sdk-ci
 
       - name: Prepare a release
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git config --global url."https://x-access-token:${{ env.GENERATED_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${{ steps.get-github-token.outputs.token }}@github.com/".insteadOf "git@github.com:"
 
           devbox run make prepare-release
         env:
           TERM: 'xterm'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # to be used by `gh`
+          GH_TOKEN: ${{ steps.get-github-token.outputs.token }} # to be used by `gh`
           DRY_RUN: 'no'
           SKIP_VALIDATION: 'no'
-          GENERATED_GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Release
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git config --global url."https://x-access-token:${{ env.GENERATED_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${{ steps.get-github-token.outputs.token }}@github.com/".insteadOf "git@github.com:"
 
           devbox run ./scripts/release.sh
         env:
@@ -82,4 +72,3 @@ jobs:
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
           DRY_RUN: 'no'
-          GENERATED_GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}

--- a/.github/workflows/sdk-ci.yaml
+++ b/.github/workflows/sdk-ci.yaml
@@ -25,20 +25,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+      - name: Generate github token
+        id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.3.1
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=github_app:app-id
-            GITHUB_APP_PRIVATE_KEY=github_app:private-key
-
-      - name: Generate github private token
-        id: generate_github_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: foundation-sdk-ci
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
@@ -48,8 +39,8 @@ jobs:
 
       - name: Run codegen pipeline
         run: |
-          git config --global user.email "cog-ci@grafana.com"
-          git config --global user.name "cog - CI"
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
           devbox run make prepare-release
         env:
@@ -59,7 +50,7 @@ jobs:
           SKIP_VALIDATION: 'no'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
-          GITHUB_AUTH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          GITHUB_AUTH_TOKEN: ${{ steps.get-github-token.outputs.token }} # in case cog needs to access private repositories
 
   run_examples:
     name: Run examples
@@ -72,20 +63,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+      - name: Generate github token
+        id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.3.1
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=github_app:app-id
-            GITHUB_APP_PRIVATE_KEY=github_app:private-key
-
-      - name: Generate github private token
-        id: generate_github_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: foundation-sdk-ci
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
@@ -98,7 +80,7 @@ jobs:
           devbox run make generate
         env:
           GOGC: 'off'
-          GITHUB_AUTH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          GITHUB_AUTH_TOKEN: ${{ steps.get-github-token.outputs.token }} # in case cog needs to access private repositories
 
       - name: Run examples
         run: |
@@ -124,25 +106,16 @@ jobs:
           enable-cache: 'true'
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
-      - name: Get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+      - name: Generate github token
+        id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.3.1
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=github_app:app-id
-            GITHUB_APP_PRIVATE_KEY=github_app:private-key
-
-      - name: Generate github private token
-        id: generate_github_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: foundation-sdk-ci
 
       - name: Dry-run release with current branch
         run: |
-          git config --global user.email "cog-ci@grafana.com"
-          git config --global user.name "cog - CI"
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
           devbox run make prepare-release
         env:
@@ -152,7 +125,7 @@ jobs:
           SKIP_VALIDATION: 'yes'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
-          GITHUB_AUTH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          GITHUB_AUTH_TOKEN: ${{ steps.get-github-token.outputs.token }} # in case cog needs to access private repositories
 
       - name: Identify latest branch
         id: latest_branch

--- a/.github/workflows/sdk-ci.yaml
+++ b/.github/workflows/sdk-ci.yaml
@@ -25,6 +25,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Get secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=github_app:app-id
+            GITHUB_APP_PRIVATE_KEY=github_app:private-key
+
+      - name: Generate github private token
+        id: generate_github_token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
         with:
@@ -44,6 +59,7 @@ jobs:
           SKIP_VALIDATION: 'no'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
+          GITHUB_AUTH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
   run_examples:
     name: Run examples
@@ -56,6 +72,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Get secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=github_app:app-id
+            GITHUB_APP_PRIVATE_KEY=github_app:private-key
+
+      - name: Generate github private token
+        id: generate_github_token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
         with:
@@ -67,6 +98,7 @@ jobs:
           devbox run make generate
         env:
           GOGC: 'off'
+          GITHUB_AUTH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Run examples
         run: |
@@ -92,6 +124,21 @@ jobs:
           enable-cache: 'true'
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
+      - name: Get secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=github_app:app-id
+            GITHUB_APP_PRIVATE_KEY=github_app:private-key
+
+      - name: Generate github private token
+        id: generate_github_token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Dry-run release with current branch
         run: |
           git config --global user.email "cog-ci@grafana.com"
@@ -105,6 +152,7 @@ jobs:
           SKIP_VALIDATION: 'yes'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
+          GITHUB_AUTH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Identify latest branch
         id: latest_branch


### PR DESCRIPTION
We actually do need an app for these workflows to function properly:

* java/python/typescript releases are triggered on tag pushes events, which won't be emitted unless a user or an app pushes the tags
* for "next release" PRs: the CI won't run unless a user/an app opens them

Additionally, having an app will make it easy to access schemas from private repositories in the future (if/when needed)

Note: the app is still being setup, CI failure is expected for now.