### PR TITLE
Make sure schemas are read from a tagged version

### DIFF
--- a/.cog/resources/dashboardv2/config.yaml
+++ b/.cog/resources/dashboardv2/config.yaml
@@ -4,7 +4,7 @@
 
 inputs:
   - cue:
-      url: 'https://raw.githubusercontent.com/grafana/grafana/main/apps/dashboard/kinds/v2/dashboard_spec.cue'
+      url: 'https://raw.githubusercontent.com/grafana/grafana/v13.0.2/apps/dashboard/kinds/v2/dashboard_spec.cue'
 
       # Name of the package in which code for this resource will be generated.
       package: dashboardv2

--- a/.cog/resources/dashboardv2beta1/config.yaml
+++ b/.cog/resources/dashboardv2beta1/config.yaml
@@ -2,7 +2,7 @@
 
 inputs:
   - cue:
-      url: 'https://raw.githubusercontent.com/grafana/grafana/release-13.0.2/apps/dashboard/kinds/v2beta1/dashboard_spec.cue'
+      url: 'https://raw.githubusercontent.com/grafana/grafana/v13.0.2/apps/dashboard/kinds/v2beta1/dashboard_spec.cue'
       package: dashboardv2beta1
       metadata:
         kind: core

--- a/.cog/resources/expr/config.yaml
+++ b/.cog/resources/expr/config.yaml
@@ -2,7 +2,7 @@
 
 inputs:
   - jsonschema:
-      url: 'https://raw.githubusercontent.com/grafana/grafana/refs/heads/release-13.0.2/pkg/expr/query.request.schema.json'
+      url: 'https://raw.githubusercontent.com/grafana/grafana/v13.0.2/pkg/expr/query.request.schema.json'
       package: expr
       metadata:
         kind: composable


### PR DESCRIPTION
We want the codegen pipeline to be reproducible: having schemas read from grafana/grafana main branch doesn't really align well with that goal.