### PR TITLE
Update release process to sign commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,22 +45,54 @@ jobs:
         with:
           github_app: foundation-sdk-ci
 
+      - name: Determine release mode
+        id: release_mode
+        run: |
+          echo "mode=$(./scripts/release-mode.sh)" >> "$GITHUB_OUTPUT"
+
       - name: Prepare a release
+        id: prepare
+        if: steps.release_mode.outputs.mode == 'prepare'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git config --global url."https://x-access-token:${{ steps.get-github-token.outputs.token }}@github.com/".insteadOf "git@github.com:"
 
           devbox run make prepare-release
+
+          if [[ `git -C ./workspace/foundation-sdk/ status --porcelain` ]]; then
+            echo "has_changes=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=no" >> "$GITHUB_OUTPUT"
+          fi
         env:
           TERM: 'xterm'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
           GH_TOKEN: ${{ steps.get-github-token.outputs.token }} # to be used by `gh`
-          DRY_RUN: 'no'
           SKIP_VALIDATION: 'no'
 
+      - name: Publish prepared release in preview branch
+        if: steps.release_mode.outputs.mode == 'prepare' && steps.prepare.outputs.has_changes == 'yes'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465  # v0.2.22
+        with:
+          commit_message: "Prepare next release"
+          repo: ${{ github.event.pull_request.head.repo.full_name }}
+          branch: 'release-preview'
+          file_pattern: '*' # actual changes will already be `git add`-ed by the previous step
+          repository: 'workspace/foundation-sdk'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Open pull request for preview branch
+        if: steps.release_mode.outputs.mode == 'prepare' && steps.prepare.outputs.has_changes == 'yes'
+        run: |
+          ./scripts/open-release-pr.sh
+        env:
+          GH_TOKEN: ${{ steps.get-github-token.outputs.token }} # to be used by `gh`
+
       - name: Release
+        if: steps.release_mode.outputs.mode == 'release'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/scripts/open-release-pr.sh
+++ b/scripts/open-release-pr.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Exit on error. Append "|| true" if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump | gzip`
+set -o pipefail
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${__dir}/libs/logs.sh"
+source "${__dir}/libs/git.sh"
+
+# These environment variables can be used to alter the behavior of the script.
+
+FOUNDATION_SDK_PATH=${FOUNDATION_SDK_PATH:-'./'}
+FOUNDATION_SDK_REPO=${FOUNDATION_SDK_REPO:-'git@github.com:grafana/grafana-foundation-sdk.git'}
+GH_CLI_CMD=${GH_CLI_CMD:-"gh"} # Command used to run `gh` (GitHub cli)
+
+#################
+### Usage ###
+#################
+
+# ./scripts/open-release-pr.sh
+
+#################
+### Utilities ###
+#################
+
+function gh_run() (
+  local repo_dir=${1}
+  shift
+
+  cd "$repo_dir"
+
+  $GH_CLI_CMD "$@"
+)
+
+############
+### Main ###
+############
+
+expected_pr_title="Next release"
+release_branch='release-preview'
+
+debug "Ensuring that ${FOUNDATION_SDK_REPO} will be used by gh"
+gh_run "${FOUNDATION_SDK_PATH}" repo set-default "${FOUNDATION_SDK_REPO}"
+
+pr_exists=$(gh_run "${FOUNDATION_SDK_PATH}" pr list -S "Next release")
+
+if [ "${pr_exists}" == "" ]; then
+  info "Opening release Pull Request"
+  gh_run "${FOUNDATION_SDK_PATH}" pr create \
+    --base main \
+    --head "${release_branch}" \
+    --title "${expected_pr_title}"\
+    --body "Note to maintainers: merging this PR will trigger the creation of a new release with all the modifications included on this branch. See the [release docs](https://github.com/grafana/grafana-foundation-sdk/blob/main/maintainers/releasing.md) for more information."
+else
+  debug "PR already exists"
+fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -15,8 +15,6 @@ source "${__dir}/libs/git.sh"
 
 # These environment variables can be used to alter the behavior of the release script.
 
-DRY_RUN=${DRY_RUN:-"yes"} # Some kind of fail-safe to ensure that we're only pushing something when we mean it.
-
 COG_CMD=${COG_CMD:-"cog"} # Command used to run `cog`
 GH_CLI_CMD=${GH_CLI_CMD:-"gh"} # Command used to run `gh` (GitHub cli)
 
@@ -73,18 +71,6 @@ function gh_run() (
 
   $GH_CLI_CMD "$@"
 )
-
-function run_when_safe() {
-  local command=${1}
-  shift
-
-  if [ "${DRY_RUN}" == "no" ]; then
-    ${command} "$@"
-  else
-    warning "Dry run enabled: skipping execution of \"${command} $*\""
-    info "Run this script with DRY_RUN=no to disable dry-run mode."
-  fi
-}
 
 function next_version() {
   local base="$1"
@@ -155,12 +141,6 @@ codegen_output_path="${WORKSPACE_PATH}/codegen"
 foundation_sdk_path="${WORKSPACE_PATH}/foundation-sdk"
 release_branch='release-preview'
 release_file_marker="${foundation_sdk_path}/.release/tag"
-
-if [ "${DRY_RUN}" == "no" ]; then
-  warning "Dry-run is OFF."
-else
-  notice "Dry-run is ON."
-fi
 
 if [ "${SKIP_VALIDATION}" == "yes" ]; then
   warning "Code validation is OFF."
@@ -247,28 +227,9 @@ git_run "${foundation_sdk_path}" add .
 
 has_changes=$(git_has_changes "${foundation_sdk_path}")
 if [ "${has_changes}" != "0" ]; then
-  warning "No changes detected: aborting."
+  warning "No changes detected."
   exit 0
 fi
 
-git_run "${foundation_sdk_path}" commit -m "Prepare ${next_tag} release"
-
-info "Pushing release branch ${release_branch}"
-run_when_safe git_run "${foundation_sdk_path}" push origin "+${release_branch}"
-
-debug "Ensuring that ${FOUNDATION_SDK_REPO} will be used by gh"
-run_when_safe gh_run "${foundation_sdk_path}" repo set-default "${FOUNDATION_SDK_REPO}"
-
-if [ "$release_branch_exists" != "0" ]; then
-  info "Opening release Pull Request"
-  run_when_safe gh_run "${foundation_sdk_path}" pr create \
-    --base main \
-    --head "${release_branch}" \
-    --title "Next release" \
-    --body "Note to maintainers: merging this PR will trigger the creation of a new release with all the modifications included on this branch. See the [release docs](https://github.com/grafana/grafana-foundation-sdk/blob/main/maintainers/releasing.md) for more information."
-fi
-
-if [ "${DRY_RUN}" != "no" ]; then
-  notice "Review the changes on the ${release_branch} branch in ${foundation_sdk_path} and re-run this script with DRY_RUN=no to disable dry-run mode."
-  notice "Tip: git diff main..${release_branch}"
-fi
+notice "Review the changes on the ${release_branch} branch in ${foundation_sdk_path}."
+notice "Tip: git diff main..${release_branch}"

--- a/scripts/release-mode.sh
+++ b/scripts/release-mode.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Exit on error. Append "|| true" if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump | gzip`
+set -o pipefail
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${__dir}/libs/logs.sh"
+source "${__dir}/libs/git.sh"
+
+# These environment variables can be used to alter the behavior of the script.
+
+FOUNDATION_SDK_PATH=${FOUNDATION_SDK_PATH:-'./'}
+
+#################
+### Usage ###
+#################
+
+# ./scripts/release-mode.sh
+
+############
+### Main ###
+############
+
+release_marker=".release/tag"
+
+# Make sure the tags are up-to-date
+git_run "${FOUNDATION_SDK_PATH}" fetch origin --tags 2> /dev/null
+
+# No release file means no release was ever made: nothing to release.
+if [ ! -f "${release_marker}" ]; then
+  echo "prepare"
+  exit 0
+fi
+
+latest_tag=$(git_run "${FOUNDATION_SDK_PATH}" describe --tags --match 'v*.*.*' --abbrev=0 2>/dev/null || echo 'v0.0.0')
+current_marker=$(cat "${release_marker}")
+
+debug "latest: $latest_tag"
+debug "current_marker: $current_marker"
+
+# The release marker and latest tags are equal: we just merged the
+# release PR and already performed the release. Let's prepare a new one.
+if [ "${latest_tag}" == "${current_marker}" ]; then
+  echo "prepare"
+  exit 0
+fi
+
+# The release marker and latest tags are different: we just merged the
+# release PR and should perform the release now.
+echo "release"
+exit 0


### PR DESCRIPTION
Commits are now required to be signed to reach the main branch.

As the release process for the Foundation SDK runs the codegen and commits the results in the CI, we need to update it so that it signs the generated commits.