### PR TITLE
Fix release mode detection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          fetch-depth: 0 # necessary for the release mode detection to work correctly
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0


### PR DESCRIPTION
To detect whether we're performing a release or merely preparing one, the CI calls something like `git describe --tags --match 'v*.*.*' --abbrev=0`. For this command to work as expected, it needs the repository's history.