### PR TITLE
Never cleanup the workspace when preparing a release

### DIFF
--- a/.github/workflows/sdk-ci.yaml
+++ b/.github/workflows/sdk-ci.yaml
@@ -46,7 +46,6 @@ jobs:
         env:
           TERM: 'xterm'
           WORKSPACE_PATH: /tmp/foundation-workspace-current
-          CLEANUP_WORKSPACE: 'no'
           SKIP_VALIDATION: 'no'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
@@ -121,7 +120,6 @@ jobs:
         env:
           TERM: 'xterm'
           WORKSPACE_PATH: /tmp/foundation-workspace-current
-          CLEANUP_WORKSPACE: 'no'
           SKIP_VALIDATION: 'yes'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -26,7 +26,6 @@ KIND_REGISTRY_REPO=${KIND_REGISTRY_REPO:-'https://github.com/grafana/kind-regist
 FOUNDATION_SDK_REPO=${FOUNDATION_SDK_REPO:-'git@github.com:grafana/grafana-foundation-sdk.git'}
 
 SKIP_VALIDATION=${SKIP_VALIDATION:-"no"}
-CLEANUP_WORKSPACE=${CLEANUP_WORKSPACE:-"yes"} # Should the workspace be deleted after the script runs?
 WORKSPACE_PATH=${WORKSPACE_PATH:-'./workspace'}
 
 #################
@@ -128,14 +127,6 @@ function should_abort_prepare() {
 ############
 ### Main ###
 ############
-
-function cleanup() {
-  debug "Cleaning up workspace"
-  rm -rf "${WORKSPACE_PATH}"
-}
-if [ "${CLEANUP_WORKSPACE}" == "yes" ]; then
-  trap cleanup EXIT # run the cleanup() function on exit
-fi
 
 codegen_output_path="${WORKSPACE_PATH}/codegen"
 foundation_sdk_path="${WORKSPACE_PATH}/foundation-sdk"


### PR DESCRIPTION
Since https://github.com/grafana/grafana-foundation-sdk/pull/1301, the only purpose of this script is to run the codegen and prepare the release. It doesn't commit/push/open a PR anymore, so removing the output of this script once it's done running makes no sense anymore.