### PR TITLE
Restore HTTPS-based auth when git-cloning the SDK in the workspace

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,10 @@ jobs:
         id: prepare
         if: steps.release_mode.outputs.mode == 'prepare'
         run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global url."https://x-access-token:${{ steps.get-github-token.outputs.token }}@github.com/".insteadOf "git@github.com:"
+
           devbox run make prepare-release
 
           if [[ `git -C ./workspace/foundation-sdk/ status --porcelain` ]]; then


### PR DESCRIPTION
Turns out we still needed this :facepalm: 