### PR TITLE
Fix the detection of existing release PRs

### DIFF
--- a/scripts/open-release-pr.sh
+++ b/scripts/open-release-pr.sh
@@ -48,7 +48,7 @@ release_branch='release-preview'
 debug "Ensuring that ${FOUNDATION_SDK_REPO} will be used by gh"
 gh_run "${FOUNDATION_SDK_PATH}" repo set-default "${FOUNDATION_SDK_REPO}"
 
-pr_exists=$(gh_run "${FOUNDATION_SDK_PATH}" pr list -S "Next release")
+pr_exists=$(gh_run "${FOUNDATION_SDK_PATH}" pr list --json title | grep -q '"Next release"' || true)
 
 if [ "${pr_exists}" == "" ]; then
   info "Opening release Pull Request"


### PR DESCRIPTION
[Release commits are being signed](https://github.com/grafana/grafana-foundation-sdk/commit/29293b01954aec4b72199edd7a712e8e1ab1654a)

Once "release preview PRs" will be created correctly again (this PR), the release process should be back to functional.