### PR TITLE
Use Node.js 24 in Typescript release job

### DIFF
--- a/.github/workflows/typescript-release.yaml
+++ b/.github/workflows/typescript-release.yaml
@@ -4,7 +4,7 @@ on:
     tags: ["v*"]
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '24' # Current LTS
 
 jobs:
   release:


### PR DESCRIPTION
Bump the Node.js version used in the Typescript release job to 24.x, as it's the current LTS version.

Should also fix https://github.com/grafana/grafana-foundation-sdk/actions/runs/34343210436/job/102438620315#step:4:13