### PR TITLE
Bump pypa/gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -41,7 +41,7 @@ jobs:
         run: python3 -m build
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: python/dist/
           attestations: false


### PR DESCRIPTION
Make sure the action is up-to-date before diving into https://github.com/grafana/grafana-foundation-sdk/actions/runs/34343209932/job/102438619671#step:6:170